### PR TITLE
fix: actionable error handling for Firestore rules deploy

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -82,11 +82,18 @@ jobs:
 
       - name: Deploy Firestore rules and indexes
         run: |
-          GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-key.json \
+          set -o pipefail
+          FIRESTORE_DEPLOY_LOG=$(mktemp)
+          if ! GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-key.json \
             npx firebase-tools deploy \
             --only firestore:rules,firestore:indexes \
             --project rush-n-relax \
-            --non-interactive
+            --non-interactive 2>&1 | tee "$FIRESTORE_DEPLOY_LOG"; then
+            if grep -qi "403\|does not have permission\|firebaserules" "$FIRESTORE_DEPLOY_LOG"; then
+              echo "::error::Deploy service account is missing firebaserules permissions. Grant roles/firebase.rulesAdmin to FIREBASE_SERVICE_ACCOUNT_RUSH_N_RELAX."
+            fi
+            exit 1
+          fi
 
       - name: Deploy Storage rules
         run: |


### PR DESCRIPTION
Wraps the "Deploy Firestore rules and indexes" step with the same log-capture + annotation pattern already used by the Storage deploy step. Detects 403/permission errors and emits a ::error:: annotation pointing at the missing IAM role (roles/firebase.rulesAdmin) rather than surfacing a raw HTTP 403 with no context.