### PR TITLE
test: admin action and repository unit coverage

### DIFF
--- a/src/__tests__/app/admin/categories/actions.test.ts
+++ b/src/__tests__/app/admin/categories/actions.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { requireRoleMock, setCategoryStatusMock, revalidatePathMock } =
+  vi.hoisted(() => ({
+    requireRoleMock: vi.fn(),
+    setCategoryStatusMock: vi.fn().mockResolvedValue(undefined),
+    revalidatePathMock: vi.fn(),
+  }));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  setCategoryStatus: setCategoryStatusMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+import { toggleCategoryStatus } from '@/app/(admin)/admin/categories/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function stubUnauthorised() {
+  requireRoleMock.mockImplementation(() => {
+    throw new Error('NEXT_REDIRECT:/admin/login');
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('toggleCategoryStatus server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given an unauthenticated caller', () => {
+    it('propagates the redirect thrown by requireRole', async () => {
+      stubUnauthorised();
+
+      await expect(toggleCategoryStatus('flower', true)).rejects.toThrow(
+        'NEXT_REDIRECT:/admin/login'
+      );
+
+      expect(setCategoryStatusMock).not.toHaveBeenCalled();
+      expect(revalidatePathMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a currently-active category', () => {
+    it('calls setCategoryStatus with false (deactivate)', async () => {
+      stubAuthorisedActor();
+
+      await toggleCategoryStatus('flower', true);
+
+      expect(setCategoryStatusMock).toHaveBeenCalledOnce();
+      expect(setCategoryStatusMock).toHaveBeenCalledWith('flower', false);
+    });
+  });
+
+  describe('given a currently-inactive category', () => {
+    it('calls setCategoryStatus with true (activate)', async () => {
+      stubAuthorisedActor();
+
+      await toggleCategoryStatus('flower', false);
+
+      expect(setCategoryStatusMock).toHaveBeenCalledOnce();
+      expect(setCategoryStatusMock).toHaveBeenCalledWith('flower', true);
+    });
+  });
+
+  describe('given a successful toggle', () => {
+    it('revalidates the expected paths', async () => {
+      stubAuthorisedActor();
+
+      await toggleCategoryStatus('flower', true);
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/categories');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products');
+    });
+  });
+});

--- a/src/__tests__/app/admin/categories/edit/actions.test.ts
+++ b/src/__tests__/app/admin/categories/edit/actions.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  requireRoleMock,
+  upsertCategoryMock,
+  getCategoryBySlugMock,
+  revalidatePathMock,
+  redirectMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  upsertCategoryMock: vi.fn().mockResolvedValue('flower'),
+  getCategoryBySlugMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertCategory: upsertCategoryMock,
+  getCategoryBySlug: getCategoryBySlugMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { updateCategory } from '@/app/(admin)/admin/categories/[slug]/edit/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function stubExistingCategory(overrides: Record<string, unknown> = {}) {
+  getCategoryBySlugMock.mockResolvedValue({
+    slug: 'flower',
+    label: 'Flower',
+    description: 'Premium flower',
+    order: 1,
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+}
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    label: 'Updated Flower',
+    description: 'Updated description',
+    order: '2',
+    isActive: 'true',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('updateCategory server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a non-existent category slug', () => {
+    it('returns a not-found error', async () => {
+      stubAuthorisedActor();
+      getCategoryBySlugMock.mockResolvedValue(null);
+
+      const result = await updateCategory(
+        'ghost-category',
+        null,
+        makeFormData()
+      );
+
+      expect(result).toEqual({ error: 'Category not found.' });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given order = 0', () => {
+    it('returns an order validation error', async () => {
+      stubAuthorisedActor();
+      stubExistingCategory();
+
+      const result = await updateCategory(
+        'flower',
+        null,
+        makeFormData({ order: '0' })
+      );
+
+      expect(result).toEqual({ error: 'Order must be a positive integer.' });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a negative order', () => {
+    it('returns an order validation error', async () => {
+      stubAuthorisedActor();
+      stubExistingCategory();
+
+      const result = await updateCategory(
+        'flower',
+        null,
+        makeFormData({ order: '-5' })
+      );
+
+      expect(result).toEqual({ error: 'Order must be a positive integer.' });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when label is absent', async () => {
+      stubAuthorisedActor();
+      stubExistingCategory();
+
+      const result = await updateCategory(
+        'flower',
+        null,
+        makeFormData({ label: '' })
+      );
+
+      expect(result).toEqual({ error: 'All required fields must be filled.' });
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('calls upsertCategory with the correct fields', async () => {
+      stubAuthorisedActor();
+      stubExistingCategory();
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateCategory('flower', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(upsertCategoryMock).toHaveBeenCalledOnce();
+      const [payload] = upsertCategoryMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.slug).toBe('flower');
+      expect(payload.label).toBe('Updated Flower');
+      expect(payload.order).toBe(2);
+    });
+
+    it('revalidates paths and redirects to /admin/categories', async () => {
+      stubAuthorisedActor();
+      stubExistingCategory();
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateCategory('flower', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/categories');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products');
+      expect(redirectMock).toHaveBeenCalledWith('/admin/categories');
+    });
+  });
+});

--- a/src/__tests__/app/admin/categories/new/actions.test.ts
+++ b/src/__tests__/app/admin/categories/new/actions.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  requireRoleMock,
+  upsertCategoryMock,
+  getCategoryBySlugMock,
+  revalidatePathMock,
+  redirectMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  upsertCategoryMock: vi.fn().mockResolvedValue('flower'),
+  getCategoryBySlugMock: vi.fn().mockResolvedValue(null),
+  revalidatePathMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertCategory: upsertCategoryMock,
+  getCategoryBySlug: getCategoryBySlugMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { createCategory } from '@/app/(admin)/admin/categories/new/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    slug: 'flower',
+    label: 'Flower',
+    description: 'Premium flower products',
+    order: '1',
+    isActive: 'true',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('createCategory server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given order = 0', () => {
+    it('returns an order validation error', async () => {
+      stubAuthorisedActor();
+
+      const result = await createCategory(null, makeFormData({ order: '0' }));
+
+      expect(result).toEqual({ error: 'Order must be a positive integer.' });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a negative order', () => {
+    it('returns an order validation error', async () => {
+      stubAuthorisedActor();
+
+      const result = await createCategory(null, makeFormData({ order: '-1' }));
+
+      expect(result).toEqual({ error: 'Order must be a positive integer.' });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a non-numeric order', () => {
+    it('returns an order validation error', async () => {
+      stubAuthorisedActor();
+
+      const result = await createCategory(null, makeFormData({ order: 'abc' }));
+
+      expect(result).toEqual({ error: 'Order must be a positive integer.' });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid slug format', () => {
+    it('returns a slug-format error for spaces', async () => {
+      stubAuthorisedActor();
+
+      const result = await createCategory(
+        null,
+        makeFormData({ slug: 'bad slug' })
+      );
+
+      expect(result).toEqual({
+        error: 'Slug must be lowercase letters, numbers, and hyphens only.',
+      });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a slug that already exists', () => {
+    it('returns a slug-uniqueness error', async () => {
+      stubAuthorisedActor();
+      getCategoryBySlugMock.mockResolvedValue({
+        slug: 'flower',
+        label: 'Flower',
+        order: 1,
+        isActive: true,
+        description: 'Existing category',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const result = await createCategory(null, makeFormData());
+
+      expect(result).toEqual({
+        error: 'A category with slug "flower" already exists.',
+      });
+      expect(upsertCategoryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when label is absent', async () => {
+      stubAuthorisedActor();
+
+      const result = await createCategory(null, makeFormData({ label: '' }));
+
+      expect(result).toEqual({ error: 'All required fields must be filled.' });
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('calls upsertCategory with correct fields', async () => {
+      stubAuthorisedActor();
+      getCategoryBySlugMock.mockResolvedValue(null);
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(createCategory(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(upsertCategoryMock).toHaveBeenCalledOnce();
+      const [payload] = upsertCategoryMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.slug).toBe('flower');
+      expect(payload.label).toBe('Flower');
+      expect(payload.order).toBe(1);
+      expect(payload.isActive).toBe(true);
+    });
+
+    it('revalidates paths and redirects to /admin/categories', async () => {
+      stubAuthorisedActor();
+      getCategoryBySlugMock.mockResolvedValue(null);
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(createCategory(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/categories');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products');
+      expect(redirectMock).toHaveBeenCalledWith('/admin/categories');
+    });
+  });
+});

--- a/src/__tests__/app/admin/email-templates/actions.test.ts
+++ b/src/__tests__/app/admin/email-templates/actions.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  requireRoleMock,
+  upsertEmailTemplateMock,
+  restoreEmailTemplateRevisionMock,
+  queueTestContactEmailMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  upsertEmailTemplateMock: vi.fn().mockResolvedValue(undefined),
+  restoreEmailTemplateRevisionMock: vi.fn().mockResolvedValue(undefined),
+  queueTestContactEmailMock: vi.fn().mockResolvedValue('job-id'),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories/email-template.repository', () => ({
+  upsertEmailTemplate: upsertEmailTemplateMock,
+  restoreEmailTemplateRevision: restoreEmailTemplateRevisionMock,
+}));
+
+vi.mock('@/lib/repositories/contact.repository', () => ({
+  queueTestContactEmail: queueTestContactEmailMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+import {
+  saveEmailTemplate,
+  sendTestEmail,
+  restoreTemplateRevision,
+} from '@/app/(admin)/admin/email-templates/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+const VALID_TEMPLATE_JSON = JSON.stringify({
+  id: 'contact-submission-default',
+  name: 'Contact Submission Default',
+  subjectTemplate: 'New contact submission from {{name}}',
+  status: 'published',
+  theme: {
+    backgroundColor: '#0b1220',
+    panelColor: '#111a2b',
+    textColor: '#dce3f1',
+    accentColor: '#d8c488',
+    mutedTextColor: '#8fa6c8',
+    borderColor: '#2a3b5f',
+    fontFamily: 'sans-serif',
+    borderRadiusPx: 14,
+  },
+  containers: [],
+});
+
+function makeSaveFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    templateJson: VALID_TEMPLATE_JSON,
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+function makeSendTestFormData(
+  overrides: Record<string, string> = {}
+): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    to: 'test@example.com',
+    templateId: 'contact-submission-default',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+function makeRestoreFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    revisionId: 'rev-abc123',
+    templateId: 'contact-submission-default',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+// ── saveEmailTemplate ─────────────────────────────────────────────────────
+
+describe('saveEmailTemplate server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given missing templateJson', () => {
+    it('returns a required-payload error', async () => {
+      stubAuthorisedActor();
+
+      const result = await saveEmailTemplate(
+        null,
+        makeSaveFormData({ templateJson: '' })
+      );
+
+      expect(result).toEqual({ error: 'Template payload is required.' });
+      expect(upsertEmailTemplateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid status enum in the JSON', () => {
+    it('returns a template-invalid error', async () => {
+      stubAuthorisedActor();
+
+      const badJson = JSON.stringify({
+        id: 'contact-submission-default',
+        name: 'Test',
+        subjectTemplate: 'Hello',
+        status: 'invalid-status',
+        theme: {},
+        containers: [],
+      });
+
+      const result = await saveEmailTemplate(
+        null,
+        makeSaveFormData({ templateJson: badJson })
+      );
+
+      expect(result).toEqual({ error: 'Template payload is invalid.' });
+      expect(upsertEmailTemplateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid (too short) template id', () => {
+    it('returns a template-invalid error', async () => {
+      stubAuthorisedActor();
+
+      const badJson = JSON.stringify({
+        id: 'ab', // less than 3 chars
+        name: 'Test',
+        subjectTemplate: 'Hello',
+        status: 'published',
+        theme: {},
+        containers: [],
+      });
+
+      const result = await saveEmailTemplate(
+        null,
+        makeSaveFormData({ templateJson: badJson })
+      );
+
+      expect(result).toEqual({ error: 'Template payload is invalid.' });
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('calls upsertEmailTemplate and returns success', async () => {
+      stubAuthorisedActor();
+
+      const result = await saveEmailTemplate(null, makeSaveFormData());
+
+      expect(upsertEmailTemplateMock).toHaveBeenCalledOnce();
+      expect(result).toEqual({ success: 'Template saved.' });
+    });
+
+    it('revalidates /admin/email-templates', async () => {
+      stubAuthorisedActor();
+
+      await saveEmailTemplate(null, makeSaveFormData());
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/email-templates');
+    });
+  });
+});
+
+// ── sendTestEmail ─────────────────────────────────────────────────────────
+
+describe('sendTestEmail server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a malformed email address', () => {
+    it('returns an invalid-email error', async () => {
+      stubAuthorisedActor();
+
+      const result = await sendTestEmail(
+        null,
+        makeSendTestFormData({ to: 'not-an-email' })
+      );
+
+      expect(result).toEqual({ error: 'Enter a valid test recipient email.' });
+      expect(queueTestContactEmailMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a missing recipient address', () => {
+    it('returns a required-email error', async () => {
+      stubAuthorisedActor();
+
+      const result = await sendTestEmail(
+        null,
+        makeSendTestFormData({ to: '' })
+      );
+
+      expect(result).toEqual({ error: 'Test recipient email is required.' });
+      expect(queueTestContactEmailMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a valid email address', () => {
+    it('calls queueTestContactEmail and returns success', async () => {
+      stubAuthorisedActor();
+
+      const result = await sendTestEmail(null, makeSendTestFormData());
+
+      expect(queueTestContactEmailMock).toHaveBeenCalledOnce();
+      expect(result.success).toContain('test@example.com');
+    });
+  });
+});
+
+// ── restoreTemplateRevision ───────────────────────────────────────────────
+
+describe('restoreTemplateRevision server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given missing revisionId', () => {
+    it('returns a required-revision-id error', async () => {
+      stubAuthorisedActor();
+
+      const result = await restoreTemplateRevision(
+        null,
+        makeRestoreFormData({ revisionId: '' })
+      );
+
+      expect(result).toEqual({ error: 'Revision ID is required.' });
+      expect(restoreEmailTemplateRevisionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing templateId', () => {
+    it('returns a required-template-id error', async () => {
+      stubAuthorisedActor();
+
+      const result = await restoreTemplateRevision(
+        null,
+        makeRestoreFormData({ templateId: '' })
+      );
+
+      expect(result).toEqual({ error: 'Template ID is required.' });
+      expect(restoreEmailTemplateRevisionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a valid revision and template ID', () => {
+    it('calls restoreEmailTemplateRevision with correct arguments and returns success', async () => {
+      stubAuthorisedActor();
+
+      const result = await restoreTemplateRevision(null, makeRestoreFormData());
+
+      expect(restoreEmailTemplateRevisionMock).toHaveBeenCalledOnce();
+      expect(restoreEmailTemplateRevisionMock).toHaveBeenCalledWith(
+        'contact-submission-default',
+        'rev-abc123'
+      );
+      expect(result).toEqual({
+        success: 'Revision restored to the live template.',
+      });
+    });
+
+    it('revalidates /admin/email-templates', async () => {
+      stubAuthorisedActor();
+
+      await restoreTemplateRevision(null, makeRestoreFormData());
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/email-templates');
+    });
+  });
+
+  describe('given restoreEmailTemplateRevision throws', () => {
+    it('returns the error message', async () => {
+      stubAuthorisedActor();
+      restoreEmailTemplateRevisionMock.mockRejectedValue(
+        new Error('Revision not found.')
+      );
+
+      const result = await restoreTemplateRevision(null, makeRestoreFormData());
+
+      expect(result).toEqual({ error: 'Revision not found.' });
+    });
+  });
+});

--- a/src/__tests__/app/admin/locations/edit/actions.test.ts
+++ b/src/__tests__/app/admin/locations/edit/actions.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  requireRoleMock,
+  upsertLocationMock,
+  getLocationBySlugMock,
+  redirectMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  upsertLocationMock: vi.fn().mockResolvedValue('oak-ridge'),
+  getLocationBySlugMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertLocation: upsertLocationMock,
+  getLocationBySlug: getLocationBySlugMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { updateLocation } from '@/app/(admin)/admin/locations/[slug]/edit/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function stubExistingLocation(overrides: Record<string, unknown> = {}) {
+  getLocationBySlugMock.mockResolvedValue({
+    id: 'oak-ridge',
+    slug: 'oak-ridge',
+    name: 'Oak Ridge',
+    address: '123 Oak Ave',
+    city: 'Oak Ridge',
+    state: 'TN',
+    zip: '37830',
+    phone: '865-555-0100',
+    hours: '9:00 AM - 9:00 PM',
+    description: 'Our Oak Ridge location',
+    placeId: undefined,
+    coordinates: undefined,
+    socialLinkIds: undefined,
+    cloverMerchantId: undefined,
+    ogImagePath: undefined,
+    seoDescription: undefined,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+}
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    name: 'Oak Ridge Updated',
+    address: '456 Oak Blvd',
+    city: 'Oak Ridge',
+    state: 'TN',
+    zip: '37830',
+    phone: '865-555-0200',
+    openHour: '10',
+    openMinute: '00',
+    openMeridiem: 'AM',
+    closeHour: '8',
+    closeMinute: '00',
+    closeMeridiem: 'PM',
+    description: 'Updated description',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('updateLocation server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a non-existent location slug', () => {
+    it('returns a location-not-found error', async () => {
+      stubAuthorisedActor();
+      getLocationBySlugMock.mockResolvedValue(null);
+
+      const result = await updateLocation(
+        'ghost-location',
+        null,
+        makeFormData()
+      );
+
+      expect(result).toEqual({ error: 'Location not found.' });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an unsupported state', () => {
+    it('returns an invalid-state error', async () => {
+      stubAuthorisedActor();
+      stubExistingLocation();
+
+      const result = await updateLocation(
+        'oak-ridge',
+        null,
+        makeFormData({ state: 'NY' })
+      );
+
+      expect(result).toEqual({
+        error: 'State must be selected from the approved list.',
+      });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid hour option', () => {
+    it('returns an invalid-hours error for out-of-range hour', async () => {
+      stubAuthorisedActor();
+      stubExistingLocation();
+
+      const result = await updateLocation(
+        'oak-ridge',
+        null,
+        makeFormData({ closeHour: '0' })
+      );
+
+      expect(result).toEqual({
+        error: 'Hours must be selected from approved time options.',
+      });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when address is absent', async () => {
+      stubAuthorisedActor();
+      stubExistingLocation();
+
+      const result = await updateLocation(
+        'oak-ridge',
+        null,
+        makeFormData({ address: '' })
+      );
+
+      expect(result).toEqual({ error: 'All fields are required.' });
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('passes buildHoursRange output to upsertLocation', async () => {
+      stubAuthorisedActor();
+      stubExistingLocation();
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateLocation('oak-ridge', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(upsertLocationMock).toHaveBeenCalledOnce();
+      const [payload] = upsertLocationMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.hours).toBe('10:00 AM - 8:00 PM');
+    });
+
+    it('redirects to /admin/locations', async () => {
+      stubAuthorisedActor();
+      stubExistingLocation();
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateLocation('oak-ridge', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(redirectMock).toHaveBeenCalledWith('/admin/locations');
+    });
+  });
+});

--- a/src/__tests__/app/admin/locations/new/actions.test.ts
+++ b/src/__tests__/app/admin/locations/new/actions.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  requireRoleMock,
+  upsertLocationMock,
+  getLocationBySlugMock,
+  redirectMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  upsertLocationMock: vi.fn().mockResolvedValue('oak-ridge'),
+  getLocationBySlugMock: vi.fn().mockResolvedValue(null),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertLocation: upsertLocationMock,
+  getLocationBySlug: getLocationBySlugMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { createLocation } from '@/app/(admin)/admin/locations/new/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    slug: 'oak-ridge',
+    name: 'Oak Ridge',
+    address: '123 Oak Ave',
+    city: 'Oak Ridge',
+    state: 'TN',
+    zip: '37830',
+    phone: '865-555-0100',
+    openHour: '9',
+    openMinute: '00',
+    openMeridiem: 'AM',
+    closeHour: '9',
+    closeMinute: '00',
+    closeMeridiem: 'PM',
+    description: 'Our Oak Ridge location',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('createLocation server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given an unsupported state', () => {
+    it('returns an invalid-state error', async () => {
+      stubAuthorisedActor();
+
+      const result = await createLocation(null, makeFormData({ state: 'CA' }));
+
+      expect(result).toEqual({
+        error: 'State must be selected from the approved list.',
+      });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid hour option', () => {
+    it('returns an invalid-hours error for out-of-range hour', async () => {
+      stubAuthorisedActor();
+
+      const result = await createLocation(
+        null,
+        makeFormData({ openHour: '13' })
+      );
+
+      expect(result).toEqual({
+        error: 'Hours must be selected from approved time options.',
+      });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+
+    it('returns an invalid-hours error for invalid minute option', async () => {
+      stubAuthorisedActor();
+
+      const result = await createLocation(
+        null,
+        makeFormData({ openMinute: '07' })
+      );
+
+      expect(result).toEqual({
+        error: 'Hours must be selected from approved time options.',
+      });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+
+    it('returns an invalid-hours error for invalid meridiem option', async () => {
+      stubAuthorisedActor();
+
+      const result = await createLocation(
+        null,
+        makeFormData({ openMeridiem: 'XX' })
+      );
+
+      expect(result).toEqual({
+        error: 'Hours must be selected from approved time options.',
+      });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when name is absent', async () => {
+      stubAuthorisedActor();
+
+      const result = await createLocation(null, makeFormData({ name: '' }));
+
+      expect(result).toEqual({ error: 'All fields are required.' });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a slug that already exists', () => {
+    it('returns a slug-uniqueness error', async () => {
+      stubAuthorisedActor();
+      getLocationBySlugMock.mockResolvedValue({
+        id: 'oak-ridge',
+        slug: 'oak-ridge',
+        name: 'Oak Ridge',
+      });
+
+      const result = await createLocation(null, makeFormData());
+
+      expect(result).toEqual({
+        error: 'A location with slug "oak-ridge" already exists.',
+      });
+      expect(upsertLocationMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('passes buildHoursRange output to upsertLocation', async () => {
+      stubAuthorisedActor();
+      getLocationBySlugMock.mockResolvedValue(null);
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(createLocation(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(upsertLocationMock).toHaveBeenCalledOnce();
+      const [payload] = upsertLocationMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      // buildHoursRange formats as "openTime - closeTime"
+      expect(payload.hours).toBe('9:00 AM - 9:00 PM');
+      expect(payload.slug).toBe('oak-ridge');
+      expect(payload.state).toBe('TN');
+    });
+
+    it('redirects to /admin/locations', async () => {
+      stubAuthorisedActor();
+      getLocationBySlugMock.mockResolvedValue(null);
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(createLocation(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(redirectMock).toHaveBeenCalledWith('/admin/locations');
+    });
+  });
+});

--- a/src/__tests__/app/admin/products/actions.test.ts
+++ b/src/__tests__/app/admin/products/actions.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { requireRoleMock, setProductStatusMock, revalidatePathMock } =
+  vi.hoisted(() => ({
+    requireRoleMock: vi.fn(),
+    setProductStatusMock: vi.fn().mockResolvedValue(undefined),
+    revalidatePathMock: vi.fn(),
+  }));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  setProductStatus: setProductStatusMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+import {
+  archiveProduct,
+  restoreProduct,
+} from '@/app/(admin)/admin/products/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function stubUnauthorised() {
+  requireRoleMock.mockImplementation(() => {
+    throw new Error('NEXT_REDIRECT:/admin/login');
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('archiveProduct server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given an unauthenticated caller', () => {
+    it('propagates the redirect thrown by requireRole', async () => {
+      stubUnauthorised();
+
+      await expect(archiveProduct('test-product')).rejects.toThrow(
+        'NEXT_REDIRECT:/admin/login'
+      );
+
+      expect(setProductStatusMock).not.toHaveBeenCalled();
+      expect(revalidatePathMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an authorised owner', () => {
+    it('calls setProductStatus with "archived"', async () => {
+      stubAuthorisedActor();
+
+      await archiveProduct('test-product');
+
+      expect(setProductStatusMock).toHaveBeenCalledOnce();
+      expect(setProductStatusMock).toHaveBeenCalledWith(
+        'test-product',
+        'archived'
+      );
+    });
+
+    it('revalidates the expected paths', async () => {
+      stubAuthorisedActor();
+
+      await archiveProduct('test-product');
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products/test-product');
+    });
+  });
+});
+
+describe('restoreProduct server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given an unauthenticated caller', () => {
+    it('propagates the redirect thrown by requireRole', async () => {
+      stubUnauthorised();
+
+      await expect(restoreProduct('test-product')).rejects.toThrow(
+        'NEXT_REDIRECT:/admin/login'
+      );
+
+      expect(setProductStatusMock).not.toHaveBeenCalled();
+      expect(revalidatePathMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an authorised owner', () => {
+    it('calls setProductStatus with "active"', async () => {
+      stubAuthorisedActor();
+
+      await restoreProduct('test-product');
+
+      expect(setProductStatusMock).toHaveBeenCalledOnce();
+      expect(setProductStatusMock).toHaveBeenCalledWith(
+        'test-product',
+        'active'
+      );
+    });
+
+    it('revalidates the expected paths', async () => {
+      stubAuthorisedActor();
+
+      await restoreProduct('test-product');
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products/test-product');
+    });
+  });
+});

--- a/src/__tests__/app/admin/products/edit/actions.test.ts
+++ b/src/__tests__/app/admin/products/edit/actions.test.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  requireRoleMock,
+  upsertProductMock,
+  getProductBySlugMock,
+  listActiveCategoriesMock,
+  revalidatePathMock,
+  redirectMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  upsertProductMock: vi.fn().mockResolvedValue('test-product'),
+  getProductBySlugMock: vi.fn(),
+  listActiveCategoriesMock: vi.fn().mockResolvedValue([]),
+  revalidatePathMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertProduct: upsertProductMock,
+  getProductBySlug: getProductBySlugMock,
+  listActiveCategories: listActiveCategoriesMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { updateProduct } from '@/app/(admin)/admin/products/[slug]/edit/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function stubExistingProduct(overrides: Record<string, unknown> = {}) {
+  getProductBySlugMock.mockResolvedValue({
+    id: 'test-product',
+    slug: 'test-product',
+    name: 'Original Name',
+    category: 'flower',
+    description: 'Original description',
+    details: 'Original details',
+    status: 'active',
+    image: undefined,
+    images: undefined,
+    coaUrl: undefined,
+    federalDeadlineRisk: false,
+    availableAt: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+}
+
+function makeFormData(
+  overrides: Record<string, string | string[]> = {}
+): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string | string[]> = {
+    name: 'Updated Name',
+    category: 'flower',
+    description: 'Updated description',
+    details: 'Updated details',
+    status: 'active',
+    federalDeadlineRisk: 'false',
+    availableAt: ['oak-ridge'],
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    if (Array.isArray(value)) {
+      for (const v of value) fd.append(key, v);
+    } else {
+      fd.set(key, value);
+    }
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('updateProduct server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listActiveCategoriesMock.mockResolvedValue([
+      { slug: 'flower', label: 'Flower', order: 1 },
+    ]);
+  });
+
+  describe('given a non-existent product slug', () => {
+    it('returns product-not-found error', async () => {
+      stubAuthorisedActor();
+      getProductBySlugMock.mockResolvedValue(null);
+
+      const result = await updateProduct('ghost-product', null, makeFormData());
+
+      expect(result).toEqual({ error: 'Product not found.' });
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when name is absent', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct();
+
+      const result = await updateProduct(
+        'test-product',
+        null,
+        makeFormData({ name: '' })
+      );
+
+      expect(result).toEqual({ error: 'All required fields must be filled.' });
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given compliance-hold status in the form', () => {
+    it('returns cannot-set-status error', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct();
+
+      const result = await updateProduct(
+        'test-product',
+        null,
+        makeFormData({ status: 'compliance-hold' })
+      );
+
+      expect(result).toEqual({ error: 'Cannot set that status directly.' });
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid category', () => {
+    it('returns invalid-category error', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct();
+      listActiveCategoriesMock.mockResolvedValue([
+        { slug: 'edibles', label: 'Edibles', order: 2 },
+      ]);
+
+      const result = await updateProduct(
+        'test-product',
+        null,
+        makeFormData({ category: 'flower' })
+      );
+
+      expect(result).toEqual({ error: 'Invalid category.' });
+    });
+  });
+
+  describe('gallery merge fallback', () => {
+    it('uses existing.images when no gallery paths are provided in the form', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct({
+        images: ['products/test-product/gallery-0.jpg'],
+      });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateProduct('test-product', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.images).toEqual(['products/test-product/gallery-0.jpg']);
+    });
+
+    it('uses provided gallery paths when they are present in the form', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct({
+        images: ['products/test-product/old-gallery.jpg'],
+      });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateProduct(
+          'test-product',
+          null,
+          makeFormData({
+            galleryImagePath_0: 'products/test-product/new-gallery.jpg',
+          })
+        )
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.images).toEqual(['products/test-product/new-gallery.jpg']);
+    });
+  });
+
+  describe('coaUrl preservation', () => {
+    it('includes existing coaUrl in the upsert payload', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct({ coaUrl: 'https://coa.example.com/coa.pdf' });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateProduct('test-product', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.coaUrl).toBe('https://coa.example.com/coa.pdf');
+    });
+
+    it('omits coaUrl when existing product has no coaUrl', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct({ coaUrl: undefined });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateProduct('test-product', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.coaUrl).toBeUndefined();
+    });
+  });
+
+  describe('featuredImagePath fallback', () => {
+    it('falls back to existing.image when featuredImagePath is absent from form', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct({ image: 'products/test-product/existing-hero.jpg' });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateProduct('test-product', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.image).toBe('products/test-product/existing-hero.jpg');
+    });
+
+    it('uses the new featuredImagePath when provided', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct({ image: 'products/test-product/old-hero.jpg' });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateProduct(
+          'test-product',
+          null,
+          makeFormData({
+            featuredImagePath: 'products/test-product/new-hero.jpg',
+          })
+        )
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.image).toBe('products/test-product/new-hero.jpg');
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('revalidates paths and redirects to /admin/products', async () => {
+      stubAuthorisedActor();
+      stubExistingProduct();
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updateProduct('test-product', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products/test-product');
+      expect(redirectMock).toHaveBeenCalledWith('/admin/products');
+    });
+  });
+});

--- a/src/__tests__/app/admin/products/new/actions.test.ts
+++ b/src/__tests__/app/admin/products/new/actions.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  requireRoleMock,
+  upsertProductMock,
+  getProductBySlugMock,
+  listActiveCategoriesMock,
+  revalidatePathMock,
+  redirectMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  upsertProductMock: vi.fn().mockResolvedValue('new-product'),
+  getProductBySlugMock: vi.fn().mockResolvedValue(null),
+  listActiveCategoriesMock: vi.fn().mockResolvedValue([]),
+  revalidatePathMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertProduct: upsertProductMock,
+  getProductBySlug: getProductBySlugMock,
+  listActiveCategories: listActiveCategoriesMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { createProduct } from '@/app/(admin)/admin/products/new/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function stubUnauthorised() {
+  requireRoleMock.mockImplementation(() => {
+    throw new Error('NEXT_REDIRECT:/admin/login');
+  });
+}
+
+function makeFormData(
+  overrides: Record<string, string | string[]> = {}
+): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string | string[]> = {
+    slug: 'test-product',
+    name: 'Test Product',
+    category: 'flower',
+    description: 'A great product',
+    details: 'Some details here',
+    federalDeadlineRisk: 'false',
+    availableAt: ['oak-ridge'],
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    if (Array.isArray(value)) {
+      for (const v of value) fd.append(key, v);
+    } else {
+      fd.set(key, value);
+    }
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('createProduct server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listActiveCategoriesMock.mockResolvedValue([
+      { slug: 'flower', label: 'Flower', order: 1 },
+    ]);
+  });
+
+  describe('given an unauthenticated caller', () => {
+    it('propagates the redirect thrown by requireRole', async () => {
+      stubUnauthorised();
+
+      await expect(createProduct(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT:/admin/login'
+      );
+
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when name is absent', async () => {
+      stubAuthorisedActor();
+
+      const result = await createProduct(null, makeFormData({ name: '' }));
+
+      expect(result).toEqual({ error: 'All required fields must be filled.' });
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid slug format', () => {
+    it('returns a slug-format error for uppercase characters', async () => {
+      stubAuthorisedActor();
+
+      const result = await createProduct(
+        null,
+        makeFormData({ slug: 'Bad Slug!' })
+      );
+
+      expect(result).toEqual({
+        error: 'Slug must be lowercase letters, numbers, and hyphens only.',
+      });
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+
+    it('returns a slug-format error for spaces', async () => {
+      stubAuthorisedActor();
+
+      const result = await createProduct(
+        null,
+        makeFormData({ slug: 'bad slug' })
+      );
+
+      expect(result).toEqual({
+        error: 'Slug must be lowercase letters, numbers, and hyphens only.',
+      });
+    });
+  });
+
+  describe('given an invalid category', () => {
+    it('returns an invalid-category error when category is not in active list', async () => {
+      stubAuthorisedActor();
+      listActiveCategoriesMock.mockResolvedValue([
+        { slug: 'edibles', label: 'Edibles', order: 2 },
+      ]);
+
+      const result = await createProduct(
+        null,
+        makeFormData({ category: 'flower' })
+      );
+
+      expect(result).toEqual({ error: 'Invalid category.' });
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a slug that already exists', () => {
+    it('returns a slug-uniqueness error', async () => {
+      stubAuthorisedActor();
+      getProductBySlugMock.mockResolvedValue({
+        id: 'test-product',
+        slug: 'test-product',
+        name: 'Existing Product',
+        status: 'active',
+      });
+
+      const result = await createProduct(null, makeFormData());
+
+      expect(result).toEqual({
+        error: 'A product with slug "test-product" already exists.',
+      });
+      expect(upsertProductMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('calls upsertProduct with the correct fields', async () => {
+      stubAuthorisedActor();
+      getProductBySlugMock.mockResolvedValue(null);
+
+      await createProduct(null, makeFormData());
+
+      expect(upsertProductMock).toHaveBeenCalledOnce();
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.slug).toBe('test-product');
+      expect(payload.name).toBe('Test Product');
+      expect(payload.category).toBe('flower');
+      expect(payload.status).toBe('active');
+    });
+
+    it('passes featuredImagePath through to upsertProduct as image', async () => {
+      stubAuthorisedActor();
+      getProductBySlugMock.mockResolvedValue(null);
+
+      await createProduct(
+        null,
+        makeFormData({ featuredImagePath: 'products/test-product/hero.jpg' })
+      );
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.image).toBe('products/test-product/hero.jpg');
+    });
+
+    it('passes undefined image when featuredImagePath is absent', async () => {
+      stubAuthorisedActor();
+      getProductBySlugMock.mockResolvedValue(null);
+
+      await createProduct(null, makeFormData());
+
+      const [payload] = upsertProductMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.image).toBeUndefined();
+    });
+
+    it('revalidates product paths and redirects to /admin/products', async () => {
+      stubAuthorisedActor();
+      getProductBySlugMock.mockResolvedValue(null);
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(createProduct(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(revalidatePathMock).toHaveBeenCalledWith('/admin/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products');
+      expect(revalidatePathMock).toHaveBeenCalledWith('/products/test-product');
+      expect(redirectMock).toHaveBeenCalledWith('/admin/products');
+    });
+  });
+});

--- a/src/__tests__/app/admin/promos/edit/actions.test.ts
+++ b/src/__tests__/app/admin/promos/edit/actions.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { requireRoleMock, upsertPromoMock, getPromoBySlugMock, redirectMock } =
+  vi.hoisted(() => ({
+    requireRoleMock: vi.fn(),
+    upsertPromoMock: vi.fn().mockResolvedValue('spring-sale'),
+    getPromoBySlugMock: vi.fn(),
+    redirectMock: vi.fn(),
+  }));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertPromo: upsertPromoMock,
+  getPromoBySlug: getPromoBySlugMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { updatePromo } from '@/app/(admin)/admin/promos/[slug]/edit/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function stubExistingPromo(overrides: Record<string, unknown> = {}) {
+  getPromoBySlugMock.mockResolvedValue({
+    id: 'spring-sale',
+    slug: 'spring-sale',
+    name: 'Spring Sale',
+    tagline: 'Save big',
+    description: 'Big discounts',
+    details: 'In-store only',
+    cta: 'Shop Now',
+    ctaPath: '/products',
+    active: true,
+    startDate: undefined,
+    endDate: undefined,
+    image: undefined,
+    keywords: undefined,
+    locationSlug: undefined,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+}
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    name: 'Updated Sale',
+    tagline: 'Updated tagline',
+    description: 'Updated description',
+    details: 'Updated details',
+    cta: 'Shop Now',
+    ctaPath: '/products',
+    active: 'true',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('updatePromo server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a non-existent promo slug', () => {
+    it('returns a promo-not-found error', async () => {
+      stubAuthorisedActor();
+      getPromoBySlugMock.mockResolvedValue(null);
+
+      const result = await updatePromo('ghost-promo', null, makeFormData());
+
+      expect(result).toEqual({ error: 'Promo not found.' });
+      expect(upsertPromoMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when name is absent', async () => {
+      stubAuthorisedActor();
+      stubExistingPromo();
+
+      const result = await updatePromo(
+        'spring-sale',
+        null,
+        makeFormData({ name: '' })
+      );
+
+      expect(result).toEqual({ error: 'All required fields must be filled.' });
+      expect(upsertPromoMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given ctaPath that does not start with /', () => {
+    it('returns a ctaPath validation error', async () => {
+      stubAuthorisedActor();
+      stubExistingPromo();
+
+      const result = await updatePromo(
+        'spring-sale',
+        null,
+        makeFormData({ ctaPath: 'https://external.com' })
+      );
+
+      expect(result).toEqual({
+        error: 'CTA Path must be an internal path starting with /.',
+      });
+    });
+  });
+
+  describe('given existing startDate/endDate preserved when form omits them', () => {
+    it('passes existing startDate to upsertPromo when form has none', async () => {
+      stubAuthorisedActor();
+      stubExistingPromo({
+        startDate: '2025-03-01',
+        endDate: '2025-03-31',
+      });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updatePromo('spring-sale', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertPromoMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.startDate).toBe('2025-03-01');
+      expect(payload.endDate).toBe('2025-03-31');
+    });
+
+    it('omits startDate/endDate when existing promo has none and form has none', async () => {
+      stubAuthorisedActor();
+      stubExistingPromo({ startDate: undefined, endDate: undefined });
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updatePromo('spring-sale', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      const [payload] = upsertPromoMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.startDate).toBeUndefined();
+      expect(payload.endDate).toBeUndefined();
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('calls upsertPromo and redirects to /admin/promos', async () => {
+      stubAuthorisedActor();
+      stubExistingPromo();
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(
+        updatePromo('spring-sale', null, makeFormData())
+      ).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(upsertPromoMock).toHaveBeenCalledOnce();
+      expect(redirectMock).toHaveBeenCalledWith('/admin/promos');
+    });
+  });
+});

--- a/src/__tests__/app/admin/promos/new/actions.test.ts
+++ b/src/__tests__/app/admin/promos/new/actions.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { requireRoleMock, upsertPromoMock, getPromoBySlugMock, redirectMock } =
+  vi.hoisted(() => ({
+    requireRoleMock: vi.fn(),
+    upsertPromoMock: vi.fn().mockResolvedValue('spring-sale'),
+    getPromoBySlugMock: vi.fn().mockResolvedValue(null),
+    redirectMock: vi.fn(),
+  }));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireRole: requireRoleMock,
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  upsertPromo: upsertPromoMock,
+  getPromoBySlug: getPromoBySlugMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import { createPromo } from '@/app/(admin)/admin/promos/new/actions';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function stubAuthorisedActor() {
+  requireRoleMock.mockResolvedValue({
+    uid: 'owner-uid',
+    email: 'owner@rushnrelax.com',
+    role: 'owner',
+  });
+}
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  const defaults: Record<string, string> = {
+    slug: 'spring-sale',
+    name: 'Spring Sale',
+    tagline: 'Save big this spring',
+    description: 'Big discounts',
+    details: 'In-store only',
+    cta: 'Shop Now',
+    ctaPath: '/products',
+    active: 'true',
+  };
+  const merged = { ...defaults, ...overrides };
+  for (const [key, value] of Object.entries(merged)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('createPromo server action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given missing required fields', () => {
+    it('returns a required-fields error when name is absent', async () => {
+      stubAuthorisedActor();
+
+      const result = await createPromo(null, makeFormData({ name: '' }));
+
+      expect(result).toEqual({ error: 'All required fields must be filled.' });
+      expect(upsertPromoMock).not.toHaveBeenCalled();
+    });
+
+    it('returns a required-fields error when ctaPath is absent', async () => {
+      stubAuthorisedActor();
+
+      const result = await createPromo(null, makeFormData({ ctaPath: '' }));
+
+      expect(result).toEqual({ error: 'All required fields must be filled.' });
+      expect(upsertPromoMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given an invalid slug format', () => {
+    it('returns a slug-format error for spaces', async () => {
+      stubAuthorisedActor();
+
+      const result = await createPromo(
+        null,
+        makeFormData({ slug: 'spring sale' })
+      );
+
+      expect(result).toEqual({
+        error: 'Slug must be lowercase letters, numbers, and hyphens only.',
+      });
+      expect(upsertPromoMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given ctaPath that does not start with /', () => {
+    it('returns a ctaPath validation error', async () => {
+      stubAuthorisedActor();
+
+      const result = await createPromo(
+        null,
+        makeFormData({ ctaPath: 'https://external.com' })
+      );
+
+      expect(result).toEqual({
+        error: 'CTA Path must be an internal path starting with /.',
+      });
+      expect(upsertPromoMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a slug that already exists', () => {
+    it('returns a slug-uniqueness error', async () => {
+      stubAuthorisedActor();
+      getPromoBySlugMock.mockResolvedValue({
+        id: 'spring-sale',
+        slug: 'spring-sale',
+        name: 'Existing Promo',
+      });
+
+      const result = await createPromo(null, makeFormData());
+
+      expect(result).toEqual({
+        error: 'A promo with slug "spring-sale" already exists.',
+      });
+      expect(upsertPromoMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('given a valid payload', () => {
+    it('calls upsertPromo and redirects to /admin/promos', async () => {
+      stubAuthorisedActor();
+      getPromoBySlugMock.mockResolvedValue(null);
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(createPromo(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      expect(upsertPromoMock).toHaveBeenCalledOnce();
+      expect(redirectMock).toHaveBeenCalledWith('/admin/promos');
+    });
+
+    it('passes all core fields to upsertPromo', async () => {
+      stubAuthorisedActor();
+      getPromoBySlugMock.mockResolvedValue(null);
+      redirectMock.mockImplementation(() => {
+        throw new Error('NEXT_REDIRECT');
+      });
+
+      await expect(createPromo(null, makeFormData())).rejects.toThrow(
+        'NEXT_REDIRECT'
+      );
+
+      const [payload] = upsertPromoMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.slug).toBe('spring-sale');
+      expect(payload.name).toBe('Spring Sale');
+      expect(payload.ctaPath).toBe('/products');
+      expect(payload.active).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/lib/repositories/category.repository.test.ts
+++ b/src/__tests__/lib/repositories/category.repository.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  docGetMock,
+  docSetMock,
+  docUpdateMock,
+  colGetMock,
+  whereMock,
+  orderByMock,
+  collectionMock,
+  getAdminFirestoreMock,
+  serverTimestampMock,
+} = vi.hoisted(() => {
+  const docGetMock = vi.fn();
+  const docSetMock = vi.fn().mockResolvedValue(undefined);
+  const docUpdateMock = vi.fn().mockResolvedValue(undefined);
+  const colGetMock = vi.fn().mockResolvedValue({ docs: [] });
+
+  const orderByMock = vi.fn().mockReturnValue({ get: colGetMock });
+  const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+
+  const collectionMock = vi.fn(() => ({
+    doc: vi.fn((id: string) => ({
+      id,
+      get: docGetMock,
+      set: docSetMock,
+      update: docUpdateMock,
+    })),
+    where: whereMock,
+    orderBy: orderByMock,
+  }));
+
+  const getAdminFirestoreMock = vi.fn(() => ({
+    collection: collectionMock,
+  }));
+
+  // Sentinel value that represents a server timestamp
+  const serverTimestampMock = Symbol('ServerTimestamp');
+
+  return {
+    docGetMock,
+    docSetMock,
+    docUpdateMock,
+    colGetMock,
+    whereMock,
+    orderByMock,
+    collectionMock,
+    getAdminFirestoreMock,
+    serverTimestampMock,
+  };
+});
+
+vi.mock('@/lib/firebase/admin', () => ({
+  getAdminFirestore: getAdminFirestoreMock,
+  toDate: (value: Date | string | undefined) =>
+    value ? new Date(value) : new Date(0),
+}));
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: {
+    serverTimestamp: () => serverTimestampMock,
+  },
+}));
+
+import {
+  upsertCategory,
+  getCategoryBySlug,
+  listActiveCategories,
+  setCategoryStatus,
+} from '@/lib/repositories/category.repository';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDocSnapshot(
+  id: string,
+  data: Record<string, unknown> | null
+): {
+  id: string;
+  exists: boolean;
+  data: () => Record<string, unknown> | undefined;
+} {
+  return {
+    id,
+    exists: data !== null,
+    data: () => data ?? undefined,
+  };
+}
+
+// ── upsertCategory ────────────────────────────────────────────────────────
+
+describe('upsertCategory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a new (non-existent) document', () => {
+    it('sets both createdAt and updatedAt on create', async () => {
+      docGetMock.mockResolvedValue(makeDocSnapshot('new-cat', null));
+
+      await upsertCategory({
+        slug: 'new-cat',
+        label: 'New Category',
+        description: 'A brand new category',
+        order: 1,
+        isActive: true,
+      });
+
+      expect(docSetMock).toHaveBeenCalledOnce();
+      const [payload] = docSetMock.mock.calls[0] as [Record<string, unknown>];
+      // Both timestamps must be present (server timestamp sentinels)
+      expect(payload.createdAt).toBe(serverTimestampMock);
+      expect(payload.updatedAt).toBe(serverTimestampMock);
+    });
+
+    it('returns the slug', async () => {
+      docGetMock.mockResolvedValue(makeDocSnapshot('new-cat', null));
+
+      const result = await upsertCategory({
+        slug: 'new-cat',
+        label: 'New Category',
+        description: 'A brand new category',
+        order: 1,
+        isActive: true,
+      });
+
+      expect(result).toBe('new-cat');
+    });
+  });
+
+  describe('given an existing document', () => {
+    it('sets only updatedAt on update (not createdAt)', async () => {
+      docGetMock.mockResolvedValue(
+        makeDocSnapshot('flower', {
+          slug: 'flower',
+          label: 'Flower',
+          description: 'Old desc',
+          order: 1,
+          isActive: true,
+        })
+      );
+
+      await upsertCategory({
+        slug: 'flower',
+        label: 'Flower Updated',
+        description: 'New desc',
+        order: 2,
+        isActive: false,
+      });
+
+      expect(docSetMock).toHaveBeenCalledOnce();
+      const [payload, options] = docSetMock.mock.calls[0] as [
+        Record<string, unknown>,
+        Record<string, unknown>,
+      ];
+      // updatedAt should be set; createdAt must NOT be in payload
+      expect(payload.updatedAt).toBe(serverTimestampMock);
+      expect('createdAt' in payload).toBe(false);
+      // Uses merge to avoid clobbering existing createdAt
+      expect(options).toEqual({ merge: true });
+    });
+  });
+});
+
+// ── getCategoryBySlug ─────────────────────────────────────────────────────
+
+describe('getCategoryBySlug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a non-existent slug', () => {
+    it('returns null', async () => {
+      docGetMock.mockResolvedValue(makeDocSnapshot('ghost', null));
+
+      const result = await getCategoryBySlug('ghost');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('given an existing slug', () => {
+    it('returns the mapped category with the document ID as slug', async () => {
+      docGetMock.mockResolvedValue(
+        makeDocSnapshot('flower', {
+          label: 'Flower',
+          description: 'Great flower',
+          order: 1,
+          isActive: true,
+          createdAt: new Date('2024-01-01').toISOString(),
+          updatedAt: new Date('2024-06-01').toISOString(),
+        })
+      );
+
+      const result = await getCategoryBySlug('flower');
+
+      expect(result).not.toBeNull();
+      expect(result!.slug).toBe('flower');
+      expect(result!.label).toBe('Flower');
+      expect(result!.order).toBe(1);
+      expect(result!.isActive).toBe(true);
+    });
+  });
+});
+
+// ── listActiveCategories ──────────────────────────────────────────────────
+
+describe('listActiveCategories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given active categories exist', () => {
+    it('returns lightweight summaries with slug from doc.id', async () => {
+      colGetMock.mockResolvedValue({
+        docs: [
+          { id: 'flower', data: () => ({ label: 'Flower', order: 1 }) },
+          { id: 'edibles', data: () => ({ label: 'Edibles', order: 2 }) },
+        ],
+      });
+
+      const result = await listActiveCategories();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].slug).toBe('flower');
+      expect(result[1].slug).toBe('edibles');
+    });
+  });
+
+  describe('given no active categories', () => {
+    it('returns an empty array', async () => {
+      colGetMock.mockResolvedValue({ docs: [] });
+
+      const result = await listActiveCategories();
+
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+// ── setCategoryStatus ─────────────────────────────────────────────────────
+
+describe('setCategoryStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a slug and isActive = false', () => {
+    it('calls update with isActive: false and a server timestamp', async () => {
+      await setCategoryStatus('flower', false);
+
+      expect(docUpdateMock).toHaveBeenCalledOnce();
+      const [payload] = docUpdateMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.isActive).toBe(false);
+      expect(payload.updatedAt).toBe(serverTimestampMock);
+    });
+  });
+
+  describe('given a slug and isActive = true', () => {
+    it('calls update with isActive: true', async () => {
+      await setCategoryStatus('flower', true);
+
+      const [payload] = docUpdateMock.mock.calls[0] as [
+        Record<string, unknown>,
+      ];
+      expect(payload.isActive).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/lib/repositories/email-template.repository.test.ts
+++ b/src/__tests__/lib/repositories/email-template.repository.test.ts
@@ -5,6 +5,9 @@ const {
   orderByMock,
   limitMock,
   getMock,
+  docGetMock,
+  batchSetMock,
+  batchCommitMock,
   collectionMock,
   getAdminFirestoreMock,
   createIdMock,
@@ -14,16 +17,21 @@ const {
   const orderByMock = vi.fn().mockReturnValue({ limit: limitMock });
   const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
 
+  // Shared doc-level get mock so tests can control per-doc responses
+  const docGetMock = vi.fn().mockResolvedValue({
+    exists: false,
+    id: 'doc-id',
+    data: () => ({}),
+  });
+
+  const batchSetMock = vi.fn();
+  const batchCommitMock = vi.fn().mockResolvedValue(undefined);
+
   const collectionMock = vi.fn(() => ({
     doc: vi.fn((name?: string) => ({
       id: name ?? 'doc-id',
-      get: vi
-        .fn()
-        .mockResolvedValue({
-          exists: false,
-          id: name ?? 'doc-id',
-          data: () => ({}),
-        }),
+      get: docGetMock,
+      set: vi.fn().mockResolvedValue(undefined),
     })),
     where: whereMock,
     orderBy: vi.fn().mockReturnValue({ get: getMock }),
@@ -32,8 +40,8 @@ const {
   const getAdminFirestoreMock = vi.fn(() => ({
     collection: collectionMock,
     batch: vi.fn(() => ({
-      set: vi.fn(),
-      commit: vi.fn().mockResolvedValue(undefined),
+      set: batchSetMock,
+      commit: batchCommitMock,
     })),
   }));
 
@@ -44,6 +52,9 @@ const {
     orderByMock,
     limitMock,
     getMock,
+    docGetMock,
+    batchSetMock,
+    batchCommitMock,
     collectionMock,
     getAdminFirestoreMock,
     createIdMock,
@@ -59,7 +70,12 @@ vi.mock('@/lib/utils/id', () => ({
   createId: createIdMock,
 }));
 
-import { listEmailTemplateRevisions } from '@/lib/repositories/email-template.repository';
+import {
+  listEmailTemplateRevisions,
+  upsertEmailTemplate,
+  getEmailTemplateById,
+  restoreEmailTemplateRevision,
+} from '@/lib/repositories/email-template.repository';
 
 describe('email-template.repository', () => {
   beforeEach(() => {
@@ -122,6 +138,192 @@ describe('email-template.repository', () => {
       await listEmailTemplateRevisions('contact-submission-default');
 
       expect(limitMock).toHaveBeenCalledWith(12);
+    });
+  });
+
+  // ── upsertEmailTemplate ──────────────────────────────────────────────────
+
+  describe('upsertEmailTemplate', () => {
+    it('writes to the templates collection and appends a revision via batch', async () => {
+      // The template doc does not exist yet (new template)
+      docGetMock.mockResolvedValue({
+        exists: false,
+        id: 'contact-submission-default',
+        data: () => ({}),
+      });
+
+      await upsertEmailTemplate({
+        id: 'contact-submission-default',
+        name: 'Contact Submission Default',
+        subjectTemplate: 'New submission from {{name}}',
+        status: 'published',
+        theme: {
+          backgroundColor: '#0b1220',
+          panelColor: '#111a2b',
+          textColor: '#dce3f1',
+          accentColor: '#d8c488',
+          mutedTextColor: '#8fa6c8',
+          borderColor: '#2a3b5f',
+          fontFamily: 'sans-serif',
+          borderRadiusPx: 14,
+        },
+        containers: [],
+      });
+
+      // batch.commit() must be called once
+      expect(batchCommitMock).toHaveBeenCalledOnce();
+
+      // batch.set() is called twice: once for template, once for revision
+      expect(batchSetMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the existing createdAt when the template document already exists', async () => {
+      const existingCreatedAt = new Date('2024-01-01').toISOString();
+      docGetMock.mockResolvedValue({
+        exists: true,
+        id: 'contact-submission-default',
+        data: () => ({ createdAt: existingCreatedAt }),
+      });
+
+      await upsertEmailTemplate({
+        id: 'contact-submission-default',
+        name: 'Contact Submission Default',
+        subjectTemplate: 'Hello',
+        status: 'published',
+        theme: {
+          backgroundColor: '#0b1220',
+          panelColor: '#111a2b',
+          textColor: '#dce3f1',
+          accentColor: '#d8c488',
+          mutedTextColor: '#8fa6c8',
+          borderColor: '#2a3b5f',
+          fontFamily: 'sans-serif',
+          borderRadiusPx: 14,
+        },
+        containers: [],
+      });
+
+      // The first batch.set() call carries the template document
+      const [, templatePayload] = batchSetMock.mock.calls[0] as [
+        unknown,
+        Record<string, unknown>,
+      ];
+      // createdAt should be the existing date, not now
+      expect((templatePayload.createdAt as Date).toISOString()).toBe(
+        existingCreatedAt
+      );
+    });
+  });
+
+  // ── getEmailTemplateById ─────────────────────────────────────────────────
+
+  describe('getEmailTemplateById', () => {
+    it('returns the default template when the document does not exist', async () => {
+      docGetMock.mockResolvedValue({
+        exists: false,
+        id: 'contact-submission-default',
+        data: () => ({}),
+      });
+
+      const result = await getEmailTemplateById('contact-submission-default');
+
+      expect(result.id).toBe('contact-submission-default');
+      expect(result.status).toBe('published');
+    });
+
+    it('returns the stored template when the document exists', async () => {
+      docGetMock.mockResolvedValue({
+        exists: true,
+        id: 'contact-submission-default',
+        data: () => ({
+          name: 'Custom Template',
+          subjectTemplate: 'Custom subject',
+          status: 'draft',
+          theme: {},
+          containers: [],
+          createdAt: new Date('2024-01-01').toISOString(),
+          updatedAt: new Date('2024-06-01').toISOString(),
+        }),
+      });
+
+      const result = await getEmailTemplateById('contact-submission-default');
+
+      expect(result.name).toBe('Custom Template');
+      expect(result.status).toBe('draft');
+    });
+  });
+
+  // ── restoreEmailTemplateRevision ─────────────────────────────────────────
+
+  describe('restoreEmailTemplateRevision', () => {
+    it('throws when the revision document does not exist', async () => {
+      docGetMock.mockResolvedValue({
+        exists: false,
+        id: 'rev-missing',
+        data: () => ({}),
+      });
+
+      await expect(
+        restoreEmailTemplateRevision(
+          'contact-submission-default',
+          'rev-missing'
+        )
+      ).rejects.toThrow('Revision not found.');
+
+      expect(batchCommitMock).not.toHaveBeenCalled();
+    });
+
+    it('throws when the revision belongs to a different template', async () => {
+      docGetMock.mockResolvedValue({
+        exists: true,
+        id: 'rev-abc',
+        data: () => ({
+          templateId: 'other-template',
+          templateName: 'Other Template',
+          subjectTemplate: 'Hello',
+          status: 'published',
+          theme: {},
+          containers: [],
+          source: 'save',
+          createdAt: new Date().toISOString(),
+        }),
+      });
+
+      await expect(
+        restoreEmailTemplateRevision('contact-submission-default', 'rev-abc')
+      ).rejects.toThrow('Revision does not belong to this template.');
+    });
+
+    it('calls batch.commit when revision matches the template', async () => {
+      // First docGetMock call: the revision doc
+      // Second docGetMock call: the existing template doc (for createdAt)
+      docGetMock
+        .mockResolvedValueOnce({
+          exists: true,
+          id: 'rev-good',
+          data: () => ({
+            templateId: 'contact-submission-default',
+            templateName: 'Contact Submission Default',
+            subjectTemplate: 'Restored subject',
+            status: 'published',
+            theme: {},
+            containers: [],
+            source: 'save',
+            createdAt: new Date().toISOString(),
+          }),
+        })
+        .mockResolvedValue({
+          exists: false,
+          id: 'contact-submission-default',
+          data: () => ({}),
+        });
+
+      await restoreEmailTemplateRevision(
+        'contact-submission-default',
+        'rev-good'
+      );
+
+      expect(batchCommitMock).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/__tests__/lib/repositories/location.repository.test.ts
+++ b/src/__tests__/lib/repositories/location.repository.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  docGetMock,
+  docSetMock,
+  colGetMock,
+  orderByMock,
+  collectionMock,
+  getAdminFirestoreMock,
+} = vi.hoisted(() => {
+  const docGetMock = vi.fn();
+  const docSetMock = vi.fn().mockResolvedValue(undefined);
+  const colGetMock = vi.fn().mockResolvedValue({ docs: [] });
+
+  const orderByMock = vi.fn().mockReturnValue({ get: colGetMock });
+
+  const collectionMock = vi.fn(() => ({
+    doc: vi.fn((id: string) => ({
+      id,
+      get: docGetMock,
+      set: docSetMock,
+    })),
+    orderBy: orderByMock,
+  }));
+
+  const getAdminFirestoreMock = vi.fn(() => ({
+    collection: collectionMock,
+  }));
+
+  return {
+    docGetMock,
+    docSetMock,
+    colGetMock,
+    orderByMock,
+    collectionMock,
+    getAdminFirestoreMock,
+  };
+});
+
+vi.mock('@/lib/firebase/admin', () => ({
+  getAdminFirestore: getAdminFirestoreMock,
+  toDate: (value: Date | string | undefined) =>
+    value ? new Date(value) : new Date(0),
+}));
+
+// React cache is a no-op in unit tests — just pass the function through
+vi.mock('react', async importOriginal => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+  };
+});
+
+import {
+  listLocations,
+  getLocationBySlug,
+  upsertLocation,
+} from '@/lib/repositories/location.repository';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDocSnapshot(
+  id: string,
+  data: Record<string, unknown> | null
+): {
+  id: string;
+  exists: boolean;
+  data: () => Record<string, unknown> | undefined;
+} {
+  return {
+    id,
+    exists: data !== null,
+    data: () => data ?? undefined,
+  };
+}
+
+function makeLocationData(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    slug: 'oak-ridge',
+    name: 'Oak Ridge',
+    address: '123 Oak Ave',
+    city: 'Oak Ridge',
+    state: 'TN',
+    zip: '37830',
+    phone: '865-555-0100',
+    hours: '9:00 AM - 9:00 PM',
+    description: 'Our Oak Ridge location',
+    createdAt: new Date('2024-01-01').toISOString(),
+    updatedAt: new Date('2024-06-01').toISOString(),
+    ...overrides,
+  };
+}
+
+// ── listLocations ─────────────────────────────────────────────────────────
+
+describe('listLocations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given multiple locations', () => {
+    it('returns lightweight summaries with slug from doc.id', async () => {
+      colGetMock.mockResolvedValue({
+        docs: [
+          {
+            id: 'maryville',
+            data: () =>
+              makeLocationData({ slug: 'maryville', name: 'Maryville' }),
+          },
+          {
+            id: 'oak-ridge',
+            data: () =>
+              makeLocationData({ slug: 'oak-ridge', name: 'Oak Ridge' }),
+          },
+        ],
+      });
+
+      const result = await listLocations();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('maryville');
+      expect(result[0].name).toBe('Maryville');
+      expect(result[1].id).toBe('oak-ridge');
+    });
+  });
+
+  describe('given no locations', () => {
+    it('returns an empty array', async () => {
+      colGetMock.mockResolvedValue({ docs: [] });
+
+      const result = await listLocations();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('given a doc where data() returns undefined', () => {
+    it('skips the phantom snapshot', async () => {
+      colGetMock.mockResolvedValue({
+        docs: [
+          { id: 'phantom', data: () => undefined },
+          {
+            id: 'real-location',
+            data: () =>
+              makeLocationData({
+                slug: 'real-location',
+                name: 'Real Location',
+              }),
+          },
+        ],
+      });
+
+      const result = await listLocations();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('real-location');
+    });
+  });
+});
+
+// ── getLocationBySlug ─────────────────────────────────────────────────────
+
+describe('getLocationBySlug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a non-existent slug', () => {
+    it('returns null', async () => {
+      docGetMock.mockResolvedValue(makeDocSnapshot('ghost', null));
+
+      const result = await getLocationBySlug('ghost');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('given an existing slug', () => {
+    it('returns the full location with all fields mapped', async () => {
+      docGetMock.mockResolvedValue(
+        makeDocSnapshot('oak-ridge', makeLocationData())
+      );
+
+      const result = await getLocationBySlug('oak-ridge');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('oak-ridge');
+      expect(result!.slug).toBe('oak-ridge');
+      expect(result!.name).toBe('Oak Ridge');
+      expect(result!.state).toBe('TN');
+      expect(result!.description).toBe('Our Oak Ridge location');
+    });
+
+    it('defaults optional fields to undefined when absent', async () => {
+      docGetMock.mockResolvedValue(
+        makeDocSnapshot('oak-ridge', makeLocationData())
+      );
+
+      const result = await getLocationBySlug('oak-ridge');
+
+      expect(result!.coordinates).toBeUndefined();
+      expect(result!.socialLinkIds).toBeUndefined();
+      expect(result!.cloverMerchantId).toBeUndefined();
+      expect(result!.ogImagePath).toBeUndefined();
+      expect(result!.seoDescription).toBeUndefined();
+    });
+  });
+});
+
+// ── upsertLocation ────────────────────────────────────────────────────────
+
+describe('upsertLocation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a valid location payload', () => {
+    it('calls set with merge: true on the correct doc and returns the slug', async () => {
+      const result = await upsertLocation({
+        slug: 'seymour',
+        name: 'Seymour',
+        address: '789 Seymour Rd',
+        city: 'Seymour',
+        state: 'TN',
+        zip: '37865',
+        phone: '865-555-0300',
+        hours: '9:00 AM - 8:00 PM',
+        description: 'Our Seymour location',
+      });
+
+      expect(result).toBe('seymour');
+      expect(docSetMock).toHaveBeenCalledOnce();
+      const [payload, options] = docSetMock.mock.calls[0] as [
+        Record<string, unknown>,
+        Record<string, unknown>,
+      ];
+      expect(payload.slug).toBe('seymour');
+      expect(payload.name).toBe('Seymour');
+      expect(payload.updatedAt).toBeInstanceOf(Date);
+      expect(options).toEqual({ merge: true });
+    });
+
+    it('strips undefined optional fields from the payload', async () => {
+      await upsertLocation({
+        slug: 'seymour',
+        name: 'Seymour',
+        address: '789 Seymour Rd',
+        city: 'Seymour',
+        state: 'TN',
+        zip: '37865',
+        phone: '865-555-0300',
+        hours: '9:00 AM - 8:00 PM',
+        description: 'Our Seymour location',
+        // coordinates intentionally absent
+      });
+
+      const [payload] = docSetMock.mock.calls[0] as [Record<string, unknown>];
+      expect('coordinates' in payload).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/lib/repositories/product.repository.test.ts
+++ b/src/__tests__/lib/repositories/product.repository.test.ts
@@ -2,28 +2,44 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
 
-const { docGetMock, docUpdateMock, collectionMock, getAdminFirestoreMock } =
-  vi.hoisted(() => {
-    const docGetMock = vi.fn();
-    const docUpdateMock = vi.fn().mockResolvedValue(undefined);
+const {
+  docGetMock,
+  docSetMock,
+  docUpdateMock,
+  colGetMock,
+  collectionMock,
+  getAdminFirestoreMock,
+} = vi.hoisted(() => {
+  const docGetMock = vi.fn();
+  const docSetMock = vi.fn().mockResolvedValue(undefined);
+  const docUpdateMock = vi.fn().mockResolvedValue(undefined);
+  const colGetMock = vi.fn().mockResolvedValue({ docs: [] });
 
-    const collectionMock = vi.fn(() => ({
-      doc: vi.fn((id: string) => ({
-        id,
-        get: docGetMock,
-        update: docUpdateMock,
-      })),
-      where: vi.fn().mockReturnThis(),
-      orderBy: vi.fn().mockReturnThis(),
-      get: vi.fn().mockResolvedValue({ docs: [] }),
-    }));
+  const collectionMock = vi.fn(() => ({
+    doc: vi.fn((id: string) => ({
+      id,
+      get: docGetMock,
+      set: docSetMock,
+      update: docUpdateMock,
+    })),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    get: colGetMock,
+  }));
 
-    const getAdminFirestoreMock = vi.fn(() => ({
-      collection: collectionMock,
-    }));
+  const getAdminFirestoreMock = vi.fn(() => ({
+    collection: collectionMock,
+  }));
 
-    return { docGetMock, docUpdateMock, collectionMock, getAdminFirestoreMock };
-  });
+  return {
+    docGetMock,
+    docSetMock,
+    docUpdateMock,
+    colGetMock,
+    collectionMock,
+    getAdminFirestoreMock,
+  };
+});
 
 vi.mock('@/lib/firebase/admin', () => ({
   getAdminFirestore: getAdminFirestoreMock,
@@ -34,6 +50,11 @@ vi.mock('@/lib/firebase/admin', () => ({
 import {
   listProductsByIds,
   setProductStatus,
+  upsertProduct,
+  getProductBySlug,
+  listProducts,
+  listAllProducts,
+  listProductsByCategory,
 } from '@/lib/repositories/product.repository';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -41,7 +62,11 @@ import {
 function makeDocSnapshot(
   id: string,
   data: Record<string, unknown> | null
-): { id: string; exists: boolean; data: () => Record<string, unknown> | undefined } {
+): {
+  id: string;
+  exists: boolean;
+  data: () => Record<string, unknown> | undefined;
+} {
   return {
     id,
     exists: data !== null,
@@ -124,9 +149,7 @@ describe('listProductsByIds', () => {
       });
       const missing = makeDocSnapshot('product-missing', null);
 
-      docGetMock
-        .mockResolvedValueOnce(existing)
-        .mockResolvedValueOnce(missing);
+      docGetMock.mockResolvedValueOnce(existing).mockResolvedValueOnce(missing);
 
       const result = await listProductsByIds(['product-a', 'product-missing']);
 
@@ -144,7 +167,7 @@ describe('setProductStatus', () => {
   });
 
   describe('given a non-existent product slug', () => {
-    it("throws a descriptive error containing the slug", async () => {
+    it('throws a descriptive error containing the slug', async () => {
       docGetMock.mockResolvedValue(makeDocSnapshot('ghost-product', null));
 
       await expect(
@@ -173,6 +196,235 @@ describe('setProductStatus', () => {
       ];
       expect(updatePayload.status).toBe('compliance-hold');
       expect(updatePayload.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+});
+
+// ── upsertProduct ──────────────────────────────────────────────────────────
+
+describe('upsertProduct', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a valid product payload', () => {
+    it('calls set with merge: true and returns the slug', async () => {
+      const result = await upsertProduct({
+        slug: 'blue-dream',
+        name: 'Blue Dream',
+        category: 'flower',
+        description: 'A classic sativa',
+        details: 'Smooth and uplifting',
+        status: 'active',
+        federalDeadlineRisk: false,
+        availableAt: ['oak-ridge'],
+      });
+
+      expect(result).toBe('blue-dream');
+      expect(docSetMock).toHaveBeenCalledOnce();
+      const [payload, options] = docSetMock.mock.calls[0] as [
+        Record<string, unknown>,
+        Record<string, unknown>,
+      ];
+      expect(payload.slug).toBe('blue-dream');
+      expect(payload.name).toBe('Blue Dream');
+      expect(payload.updatedAt).toBeInstanceOf(Date);
+      expect(options).toEqual({ merge: true });
+    });
+
+    it('strips undefined optional fields from the payload', async () => {
+      await upsertProduct({
+        slug: 'blue-dream',
+        name: 'Blue Dream',
+        category: 'flower',
+        description: 'Classic',
+        details: 'Details',
+        status: 'active',
+        federalDeadlineRisk: false,
+        availableAt: [],
+        // image intentionally absent
+      });
+
+      const [payload] = docSetMock.mock.calls[0] as [Record<string, unknown>];
+      expect('image' in payload).toBe(false);
+    });
+  });
+});
+
+// ── getProductBySlug ───────────────────────────────────────────────────────
+
+describe('getProductBySlug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a non-existent slug', () => {
+    it('returns null', async () => {
+      docGetMock.mockResolvedValue(makeDocSnapshot('ghost', null));
+
+      const result = await getProductBySlug('ghost');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('given an existing slug', () => {
+    it('returns the full product with all fields mapped', async () => {
+      docGetMock.mockResolvedValue(
+        makeDocSnapshot('blue-dream', {
+          slug: 'blue-dream',
+          name: 'Blue Dream',
+          category: 'flower',
+          description: 'Classic sativa',
+          details: 'Smooth',
+          status: 'active',
+          federalDeadlineRisk: false,
+          availableAt: ['oak-ridge'],
+          createdAt: new Date('2024-01-01').toISOString(),
+          updatedAt: new Date('2024-06-01').toISOString(),
+        })
+      );
+
+      const result = await getProductBySlug('blue-dream');
+
+      expect(result).not.toBeNull();
+      expect(result!.slug).toBe('blue-dream');
+      expect(result!.name).toBe('Blue Dream');
+      expect(result!.status).toBe('active');
+      expect(result!.federalDeadlineRisk).toBe(false);
+    });
+
+    it('defaults optional fields correctly', async () => {
+      docGetMock.mockResolvedValue(
+        makeDocSnapshot('blue-dream', {
+          slug: 'blue-dream',
+          name: 'Blue Dream',
+          // coaUrl absent
+          // image absent
+        })
+      );
+
+      const result = await getProductBySlug('blue-dream');
+
+      expect(result!.coaUrl).toBeUndefined();
+      expect(result!.image).toBeUndefined();
+    });
+  });
+});
+
+// ── listProducts ───────────────────────────────────────────────────────────
+
+describe('listProducts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given active products exist', () => {
+    it('returns summaries for active products', async () => {
+      colGetMock.mockResolvedValue({
+        docs: [
+          makeDocSnapshot('blue-dream', {
+            slug: 'blue-dream',
+            name: 'Blue Dream',
+            category: 'flower',
+            description: 'Classic',
+            status: 'active',
+            availableAt: [],
+          }),
+        ],
+      });
+
+      const result = await listProducts();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toBe('blue-dream');
+    });
+  });
+
+  describe('given no active products', () => {
+    it('returns an empty array', async () => {
+      colGetMock.mockResolvedValue({ docs: [] });
+
+      const result = await listProducts();
+
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+// ── listAllProducts ────────────────────────────────────────────────────────
+
+describe('listAllProducts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a mix of active and archived products', () => {
+    it('returns all products regardless of status', async () => {
+      colGetMock.mockResolvedValue({
+        docs: [
+          makeDocSnapshot('archived-product', {
+            slug: 'archived-product',
+            name: 'Archived Product',
+            category: 'concentrate',
+            description: 'Old',
+            status: 'archived',
+            availableAt: [],
+          }),
+          makeDocSnapshot('blue-dream', {
+            slug: 'blue-dream',
+            name: 'Blue Dream',
+            category: 'flower',
+            description: 'Classic',
+            status: 'active',
+            availableAt: [],
+          }),
+        ],
+      });
+
+      const result = await listAllProducts();
+
+      expect(result).toHaveLength(2);
+    });
+  });
+});
+
+// ── listProductsByCategory ─────────────────────────────────────────────────
+
+describe('listProductsByCategory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given active products in a category', () => {
+    it('returns summaries for matching products', async () => {
+      colGetMock.mockResolvedValue({
+        docs: [
+          makeDocSnapshot('blue-dream', {
+            slug: 'blue-dream',
+            name: 'Blue Dream',
+            category: 'flower',
+            description: 'Classic',
+            status: 'active',
+            availableAt: [],
+          }),
+        ],
+      });
+
+      const result = await listProductsByCategory('flower');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe('flower');
+    });
+  });
+
+  describe('given no products in the category', () => {
+    it('returns an empty array', async () => {
+      colGetMock.mockResolvedValue({ docs: [] });
+
+      const result = await listProductsByCategory('nonexistent');
+
+      expect(result).toEqual([]);
     });
   });
 });

--- a/src/__tests__/lib/repositories/promo.repository.test.ts
+++ b/src/__tests__/lib/repositories/promo.repository.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const {
+  docGetMock,
+  docDeleteMock,
+  docSetMock,
+  colGetMock,
+  whereMock,
+  orderByMock,
+  collectionMock,
+  getAdminFirestoreMock,
+} = vi.hoisted(() => {
+  const docGetMock = vi.fn();
+  const docDeleteMock = vi.fn().mockResolvedValue(undefined);
+  const docSetMock = vi.fn().mockResolvedValue(undefined);
+  const colGetMock = vi.fn();
+
+  const orderByMock = vi.fn().mockReturnValue({
+    get: colGetMock,
+  });
+
+  const whereMock = vi.fn().mockReturnValue({
+    orderBy: orderByMock,
+  });
+
+  const collectionMock = vi.fn(() => ({
+    doc: vi.fn((id: string) => ({
+      id,
+      get: docGetMock,
+      delete: docDeleteMock,
+      set: docSetMock,
+    })),
+    where: whereMock,
+    orderBy: orderByMock,
+  }));
+
+  const getAdminFirestoreMock = vi.fn(() => ({
+    collection: collectionMock,
+  }));
+
+  return {
+    docGetMock,
+    docDeleteMock,
+    docSetMock,
+    colGetMock,
+    whereMock,
+    orderByMock,
+    collectionMock,
+    getAdminFirestoreMock,
+  };
+});
+
+vi.mock('@/lib/firebase/admin', () => ({
+  getAdminFirestore: getAdminFirestoreMock,
+  toDate: (value: Date | string | undefined) =>
+    value ? new Date(value) : new Date(0),
+}));
+
+import {
+  listActivePromos,
+  upsertPromo,
+  deletePromo,
+} from '@/lib/repositories/promo.repository';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makePromoDoc(
+  id: string,
+  data: Record<string, unknown>
+): { id: string; data: () => Record<string, unknown> } {
+  return { id, data: () => data };
+}
+
+// ── listActivePromos ───────────────────────────────────────────────────────
+
+describe('listActivePromos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a promo whose endDate is in the past', () => {
+    it('filters out the expired promo', async () => {
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString();
+      colGetMock.mockResolvedValue({
+        docs: [
+          makePromoDoc('expired-sale', {
+            slug: 'expired-sale',
+            name: 'Expired Sale',
+            tagline: 'Gone',
+            active: true,
+            endDate: yesterday,
+          }),
+        ],
+      });
+
+      const result = await listActivePromos();
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('given a promo with no endDate', () => {
+    it('always includes the promo regardless of current date', async () => {
+      colGetMock.mockResolvedValue({
+        docs: [
+          makePromoDoc('evergreen-promo', {
+            slug: 'evergreen-promo',
+            name: 'Evergreen Promo',
+            tagline: 'Always on',
+            active: true,
+            // endDate intentionally absent
+          }),
+        ],
+      });
+
+      const result = await listActivePromos();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toBe('evergreen-promo');
+    });
+  });
+
+  describe('given a mix of expired and non-expired promos', () => {
+    it('returns only the non-expired ones', async () => {
+      const tomorrow = new Date(Date.now() + 86_400_000).toISOString();
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString();
+
+      colGetMock.mockResolvedValue({
+        docs: [
+          makePromoDoc('future-promo', {
+            slug: 'future-promo',
+            name: 'Future Promo',
+            tagline: 'Coming soon',
+            active: true,
+            endDate: tomorrow,
+          }),
+          makePromoDoc('past-promo', {
+            slug: 'past-promo',
+            name: 'Past Promo',
+            tagline: 'Over',
+            active: true,
+            endDate: yesterday,
+          }),
+        ],
+      });
+
+      const result = await listActivePromos();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].slug).toBe('future-promo');
+    });
+  });
+
+  describe('given no active promos', () => {
+    it('returns an empty array', async () => {
+      colGetMock.mockResolvedValue({ docs: [] });
+
+      const result = await listActivePromos();
+
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+// ── upsertPromo ───────────────────────────────────────────────────────────
+
+describe('upsertPromo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a valid promo payload', () => {
+    it('calls set with merge: true on the correct doc and returns the slug', async () => {
+      const result = await upsertPromo({
+        slug: 'spring-sale',
+        name: 'Spring Sale',
+        tagline: 'Save big',
+        description: 'Big discounts this spring',
+        details: 'In-store only',
+        cta: 'Shop Now',
+        ctaPath: '/products',
+        active: true,
+      });
+
+      expect(result).toBe('spring-sale');
+      expect(docSetMock).toHaveBeenCalledOnce();
+      const [payload, options] = docSetMock.mock.calls[0] as [
+        Record<string, unknown>,
+        Record<string, unknown>,
+      ];
+      expect(payload.slug).toBe('spring-sale');
+      expect(payload.name).toBe('Spring Sale');
+      expect(payload.updatedAt).toBeInstanceOf(Date);
+      expect(options).toEqual({ merge: true });
+    });
+  });
+});
+
+// ── deletePromo ───────────────────────────────────────────────────────────
+
+describe('deletePromo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given a promo slug', () => {
+    it('calls hard-delete on the correct document', async () => {
+      await deletePromo('spring-sale');
+
+      expect(docDeleteMock).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for all previously-untested admin server actions: products, promos, categories, locations, email templates
- Adds `promo.repository.test.ts`, `category.repository.test.ts`, `location.repository.test.ts` (new files)
- Extends `product.repository.test.ts` and `email-template.repository.test.ts` with missing function coverage
- 472 tests passing (up from ~360 before this PR)

## Coverage added

| Module | Key behaviors tested |
|--------|---------------------|
| `products/new` | slug format, category validation, uniqueness, `featuredImagePath` passthrough |
| `products/edit` | compliance-hold guard, gallery merge fallback, `coaUrl` preservation |
| `products/actions` | archive/restore status values, `revalidatePath`, auth guard |
| `promos/new` | `ctaPath` must start with `/`, slug uniqueness |
| `promos/edit` | `startDate`/`endDate` preserved from existing when omitted |
| `categories/*` | `order` validation, status toggle, slug uniqueness |
| `locations/*` | state allowlist, hour/minute/meridiem validation, `buildHoursRange` output |
| `email-templates` | missing/invalid JSON, bad email, restore + redirect |
| `promo.repository` | expired-endDate filtered, no-endDate always included |
| `category.repository` | create sets both timestamps, update sets only `updatedAt` |
| `location.repository` | summary mapping, phantom-snapshot skip, `upsertLocation` merge |

## Test plan

- [ ] CI passes (lint → typecheck → unit tests)
- [ ] All tests run without emulators (all mocked at `@/lib/firebase/admin` boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)