### PR TITLE
feat: Redde Payments API docs, Cloud Function, and webhook handler [+3 more]

### DIFF
--- a/docs/engineering/redde-api.md
+++ b/docs/engineering/redde-api.md
@@ -1,0 +1,281 @@
+# Redde Payments API
+
+> Research source: public Redde developer documentation and integration guides (April 2026).
+> Fields marked **KB TO VERIFY** require KB to log into https://developers.reddedashboard.com and confirm.
+
+---
+
+## Base URL
+
+```
+https://api.reddedashboard.com/v1
+```
+
+**KB TO VERIFY** — confirm exact base URL and version prefix from the developer portal.
+
+---
+
+## Authentication
+
+Redde uses API key authentication passed as a request header.
+
+```http
+Authorization: Bearer <REDDE_API_KEY>
+Content-Type: application/json
+```
+
+**KB TO VERIFY** — confirm the header name (`Authorization: Bearer` vs a custom header like `X-Redde-Api-Key`) and whether the key is obtained per-merchant from the dashboard.
+
+---
+
+## Sandbox / Test Environment
+
+**KB TO VERIFY** — confirm:
+
+- Sandbox base URL (likely `https://sandbox.reddedashboard.com/v1` or similar)
+- How to obtain test credentials (dashboard toggle or separate account)
+- Test card numbers / phone numbers for payment simulation
+
+---
+
+## Endpoints
+
+### Initiate Payment
+
+Creates a payment transaction and returns a hosted payment URL to redirect the customer to.
+
+```
+POST /transactions/initiate
+```
+
+**Request body:**
+
+```json
+{
+  "amount": 4999,
+  "currency": "USD",
+  "orderId": "ord_abc123",
+  "description": "Rush N Relax order",
+  "customerEmail": "customer@example.com",
+  "callbackUrl": "https://rush-n-relax.com/api/redde/webhook",
+  "successUrl": "https://rush-n-relax.com/order/ord_abc123",
+  "cancelUrl": "https://rush-n-relax.com/cart"
+}
+```
+
+| Field           | Type     | Notes                                                              |
+| --------------- | -------- | ------------------------------------------------------------------ |
+| `amount`        | `number` | Amount in **cents** (or smallest currency unit) — **KB TO VERIFY** |
+| `currency`      | `string` | ISO 4217 — `"USD"`                                                 |
+| `orderId`       | `string` | Merchant-supplied reference ID                                     |
+| `description`   | `string` | Shown on the payment page                                          |
+| `customerEmail` | `string` | Optional; pre-fills payment form                                   |
+| `callbackUrl`   | `string` | Redde POSTs webhook events here                                    |
+| `successUrl`    | `string` | Redirect after successful payment                                  |
+| `cancelUrl`     | `string` | Redirect if customer cancels                                       |
+
+**KB TO VERIFY** — confirm exact field names, whether `amount` is cents or dollars, and any required vs optional fields.
+
+**Response:**
+
+```json
+{
+  "txnId": "rde_txn_xyz789",
+  "paymentUrl": "https://pay.reddedashboard.com/checkout/rde_txn_xyz789",
+  "status": "pending",
+  "expiresAt": "2026-04-12T14:00:00Z"
+}
+```
+
+**KB TO VERIFY** — confirm `txnId` and `paymentUrl` field names.
+
+---
+
+### Void Transaction
+
+Voids a pending/authorized transaction before it settles.
+
+```
+POST /transactions/{txnId}/void
+```
+
+**Request body:** empty `{}`
+
+**Response:**
+
+```json
+{
+  "txnId": "rde_txn_xyz789",
+  "status": "voided"
+}
+```
+
+**KB TO VERIFY** — confirm endpoint path and whether void requires a body.
+
+---
+
+### Refund Transaction
+
+Issues a full or partial refund on a settled transaction.
+
+```
+POST /transactions/{txnId}/refund
+```
+
+**Request body:**
+
+```json
+{
+  "amount": 4999,
+  "reason": "Customer requested refund"
+}
+```
+
+| Field    | Type     | Notes                                                           |
+| -------- | -------- | --------------------------------------------------------------- |
+| `amount` | `number` | Refund amount in cents; omit for full refund — **KB TO VERIFY** |
+| `reason` | `string` | Optional memo                                                   |
+
+**Response:**
+
+```json
+{
+  "txnId": "rde_txn_xyz789",
+  "refundId": "rde_ref_abc001",
+  "status": "refunded",
+  "amount": 4999
+}
+```
+
+**KB TO VERIFY** — confirm partial refund support and field names.
+
+---
+
+## Webhook Events
+
+Redde sends `POST` requests to the `callbackUrl` provided at transaction initiation.
+
+### Signature Verification
+
+**KB TO VERIFY** — confirm the exact signature mechanism. Expected pattern (common for payment APIs):
+
+```
+X-Redde-Signature: sha256=<hmac-hex>
+```
+
+The HMAC is computed over the raw request body using `REDDE_WEBHOOK_SECRET` as the key.
+
+Verification algorithm (Node.js):
+
+```ts
+import { createHmac, timingSafeEqual } from 'crypto';
+
+function verifyReddeSignature(
+  rawBody: Buffer,
+  signatureHeader: string | null,
+  secret: string
+): boolean {
+  if (!signatureHeader) return false;
+  const [algo, digest] = signatureHeader.split('=');
+  if (algo !== 'sha256' || !digest) return false;
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  try {
+    return timingSafeEqual(
+      Buffer.from(digest, 'hex'),
+      Buffer.from(expected, 'hex')
+    );
+  } catch {
+    return false;
+  }
+}
+```
+
+**KB TO VERIFY** — confirm header name (`X-Redde-Signature`), algorithm, and signing key source.
+
+---
+
+### Event: `payment.paid`
+
+Payment successfully completed.
+
+```json
+{
+  "event": "payment.paid",
+  "txnId": "rde_txn_xyz789",
+  "orderId": "ord_abc123",
+  "amount": 4999,
+  "currency": "USD",
+  "paidAt": "2026-04-12T13:45:00Z",
+  "customerEmail": "customer@example.com"
+}
+```
+
+**KB TO VERIFY** — confirm event name (`payment.paid` vs `transaction.success` or `paid`) and full payload shape.
+
+---
+
+### Event: `payment.failed`
+
+Payment was declined or failed.
+
+```json
+{
+  "event": "payment.failed",
+  "txnId": "rde_txn_xyz789",
+  "orderId": "ord_abc123",
+  "amount": 4999,
+  "currency": "USD",
+  "failedAt": "2026-04-12T13:46:00Z",
+  "failureReason": "insufficient_funds"
+}
+```
+
+**KB TO VERIFY** — confirm event name and `failureReason` enum values.
+
+---
+
+### Event: `payment.voided`
+
+Transaction was voided.
+
+```json
+{
+  "event": "payment.voided",
+  "txnId": "rde_txn_xyz789",
+  "orderId": "ord_abc123",
+  "amount": 4999,
+  "currency": "USD",
+  "voidedAt": "2026-04-12T13:47:00Z"
+}
+```
+
+---
+
+### Event: `payment.refunded`
+
+Refund issued on a settled transaction.
+
+```json
+{
+  "event": "payment.refunded",
+  "txnId": "rde_txn_xyz789",
+  "orderId": "ord_abc123",
+  "refundId": "rde_ref_abc001",
+  "amount": 4999,
+  "currency": "USD",
+  "refundedAt": "2026-04-12T13:48:00Z"
+}
+```
+
+---
+
+## KB Checklist Before Merging Payment Code
+
+- [ ] Confirm base URL and sandbox URL
+- [ ] Confirm auth header format and key location in dashboard
+- [ ] Confirm `initiatePayment` request/response field names (especially `amount` unit: cents vs dollars)
+- [ ] Confirm webhook signature header name and algorithm
+- [ ] Confirm event type strings (`payment.paid`, etc.)
+- [ ] Obtain sandbox API key and test credentials
+- [ ] Set Firebase Secret: `firebase functions:secrets:set REDDE_API_KEY`
+- [ ] Set Next.js env var: `REDDE_WEBHOOK_SECRET` (in Vercel environment variables)

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -514,3 +514,6 @@ export const retryFailedOutboundEmails = onSchedule(
     }
   }
 );
+
+// Redde Payments — initiates a hosted payment transaction
+export { initiatePayment } from './initiatePayment';

--- a/functions/initiatePayment.test.ts
+++ b/functions/initiatePayment.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for initiatePayment Cloud Function.
+ * Mocks Firestore and Redde HTTP call — never hits real APIs.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CartItem } from './initiatePayment';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────────
+
+const {
+  mockSet,
+  mockUpdate,
+  mockDocRef,
+  mockCollection,
+  mockFetch,
+  mockApiKeyRef,
+} = vi.hoisted(() => {
+  let docIdCounter = 0;
+  const mockSet = vi.fn().mockResolvedValue(undefined);
+  const mockUpdate = vi.fn().mockResolvedValue(undefined);
+  const mockDocRef = vi.fn(() => ({
+    id: `order-${++docIdCounter}`,
+    set: mockSet,
+    update: mockUpdate,
+  }));
+  const mockCollection = vi.fn(() => ({ doc: mockDocRef }));
+  const mockFetch = vi.fn();
+  const mockApiKeyRef = { value: 'test-redde-key' };
+  return {
+    mockSet,
+    mockUpdate,
+    mockDocRef,
+    mockCollection,
+    mockFetch,
+    mockApiKeyRef,
+  };
+});
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('firebase-admin/firestore', () => ({
+  getFirestore: vi.fn(() => ({ collection: mockCollection })),
+}));
+
+vi.mock('firebase-admin/app', () => ({
+  getApps: vi.fn(() => [{}]),
+  initializeApp: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/https', () => ({
+  onCall: vi.fn((_opts: unknown, handler: unknown) => handler),
+  HttpsError: class HttpsError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+    }
+  },
+}));
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: vi.fn(() => mockApiKeyRef),
+}));
+
+vi.mock('firebase-functions/logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+global.fetch = mockFetch as typeof fetch;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeItems(overrides: Partial<CartItem> = {}): CartItem[] {
+  return [
+    {
+      productId: 'prod-1',
+      productName: 'Blue Dream 3.5g',
+      quantity: 2,
+      unitPrice: 3500,
+      ...overrides,
+    },
+  ];
+}
+
+function mockReddeSuccess() {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      txnId: 'rde_txn_abc123',
+      paymentUrl: 'https://pay.reddedashboard.com/checkout/rde_txn_abc123',
+      status: 'pending',
+    }),
+  });
+}
+
+function mockReddeFailure(status = 502) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: async () => ({ message: 'Gateway error' }),
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('initiatePayment', () => {
+  let handler: (req: { data: unknown }) => Promise<unknown>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockApiKeyRef.value = 'test-redde-key';
+    const mod = await import('./initiatePayment');
+    // onCall mock returns the handler directly
+    handler = mod.initiatePayment as unknown as typeof handler;
+  });
+
+  describe('validation', () => {
+    it('throws invalid-argument when items is empty', async () => {
+      await expect(
+        handler({
+          data: {
+            items: [],
+            fulfillmentType: 'pickup',
+            locationId: 'oak-ridge',
+          },
+        })
+      ).rejects.toMatchObject({ code: 'invalid-argument' });
+    });
+
+    it('throws invalid-argument when an item has unitPrice 0', async () => {
+      await expect(
+        handler({
+          data: {
+            items: makeItems({ unitPrice: 0 }),
+            fulfillmentType: 'pickup',
+            locationId: 'oak-ridge',
+          },
+        })
+      ).rejects.toMatchObject({ code: 'invalid-argument' });
+    });
+
+    it('throws invalid-argument for unknown fulfillmentType', async () => {
+      await expect(
+        handler({
+          data: {
+            items: makeItems(),
+            fulfillmentType: 'drone',
+            locationId: 'oak-ridge',
+          },
+        })
+      ).rejects.toMatchObject({ code: 'invalid-argument' });
+    });
+
+    it('throws invalid-argument when locationId is missing', async () => {
+      await expect(
+        handler({
+          data: {
+            items: makeItems(),
+            fulfillmentType: 'pickup',
+            locationId: '',
+          },
+        })
+      ).rejects.toMatchObject({ code: 'invalid-argument' });
+    });
+  });
+
+  describe('happy path', () => {
+    it('creates an order doc before calling Redde', async () => {
+      mockReddeSuccess();
+      await handler({
+        data: {
+          items: makeItems(),
+          fulfillmentType: 'pickup',
+          locationId: 'oak-ridge',
+          customerEmail: 'test@example.com',
+        },
+      });
+      expect(mockSet).toHaveBeenCalledOnce();
+      const setArg = mockSet.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.status).toBe('pending');
+      expect(setArg.locationId).toBe('oak-ridge');
+    });
+
+    it('returns orderId and paymentUrl on success', async () => {
+      mockReddeSuccess();
+      const result = await handler({
+        data: {
+          items: makeItems(),
+          fulfillmentType: 'pickup',
+          locationId: 'oak-ridge',
+        },
+      });
+      expect(result).toMatchObject({
+        orderId: expect.any(String),
+        paymentUrl: 'https://pay.reddedashboard.com/checkout/rde_txn_abc123',
+      });
+    });
+
+    it('calls Redde API with correct Authorization header', async () => {
+      mockReddeSuccess();
+      await handler({
+        data: {
+          items: makeItems(),
+          fulfillmentType: 'pickup',
+          locationId: 'oak-ridge',
+        },
+      });
+      const fetchCall = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = fetchCall[1].headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer test-redde-key');
+    });
+  });
+
+  describe('Redde API failure', () => {
+    it('sets order status to failed and throws unavailable', async () => {
+      mockReddeFailure();
+      await expect(
+        handler({
+          data: {
+            items: makeItems(),
+            fulfillmentType: 'pickup',
+            locationId: 'oak-ridge',
+          },
+        })
+      ).rejects.toMatchObject({ code: 'unavailable' });
+
+      const updateArg = mockUpdate.mock.calls[0][0] as Record<string, unknown>;
+      expect(updateArg.status).toBe('failed');
+    });
+  });
+
+  describe('missing API key', () => {
+    it('sets order to failed and throws internal when REDDE_API_KEY is empty', async () => {
+      mockApiKeyRef.value = '';
+      await expect(
+        handler({
+          data: {
+            items: makeItems(),
+            fulfillmentType: 'pickup',
+            locationId: 'oak-ridge',
+          },
+        })
+      ).rejects.toMatchObject({ code: 'internal' });
+
+      const updateArg = mockUpdate.mock.calls[0][0] as Record<string, unknown>;
+      expect(updateArg.status).toBe('failed');
+    });
+  });
+});

--- a/functions/initiatePayment.ts
+++ b/functions/initiatePayment.ts
@@ -1,0 +1,275 @@
+/**
+ * initiatePayment — Cloud Function (v2 callable)
+ *
+ * Creates an order document, then calls the Redde Payments API to initiate
+ * a hosted payment transaction. Returns { orderId, paymentUrl } to the client.
+ *
+ * Depends on:
+ *   - #63 Redde API docs  (TODO fields marked below)
+ *   - #64 orders repository (types defined inline here, matching order.ts)
+ *
+ * Firebase Secret required: REDDE_API_KEY
+ *   firebase functions:secrets:set REDDE_API_KEY
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { defineSecret } from 'firebase-functions/params';
+import { logger } from 'firebase-functions/logger';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const REDDE_API_KEY = defineSecret('REDDE_API_KEY');
+
+// TODO(#63): Confirm base URL from Redde developer portal.
+const REDDE_BASE_URL = 'https://api.reddedashboard.com/v1';
+const REDDE_INITIATE_PATH = '/transactions/initiate';
+const FETCH_TIMEOUT_MS = 15_000;
+// Flat TN tax placeholder — real tax computed server-side.
+const TAX_RATE = 0.0925;
+
+// ── Domain types (mirror src/types/order.ts from #64) ────────────────────────
+
+type OrderStatus =
+  | 'pending'
+  | 'processing'
+  | 'paid'
+  | 'failed'
+  | 'refunded'
+  | 'voided';
+
+type FulfillmentType = 'pickup' | 'shipping';
+
+export interface CartItem {
+  productId: string;
+  productName: string;
+  quantity: number;
+  /** Unit price in cents. */
+  unitPrice: number;
+}
+
+export interface InitiatePaymentRequest {
+  items: CartItem[];
+  fulfillmentType: FulfillmentType;
+  locationId: string;
+  customerEmail?: string;
+}
+
+export interface InitiatePaymentResponse {
+  orderId: string;
+  paymentUrl: string;
+}
+
+// ── Redde API types ──────────────────────────────────────────────────────────
+
+interface ReddeInitiatePayload {
+  // TODO(#63): Confirm exact field names and whether amount is cents or dollars.
+  amount: number;
+  currency: string;
+  orderId: string;
+  description: string;
+  customerEmail?: string;
+  callbackUrl: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+interface ReddeInitiateResponse {
+  // TODO(#63): Confirm txnId and paymentUrl field names.
+  txnId: string;
+  paymentUrl: string;
+  status: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function calcSubtotal(items: CartItem[]): number {
+  return items.reduce((sum, item) => sum + item.unitPrice * item.quantity, 0);
+}
+
+function calcTax(subtotal: number): number {
+  return Math.round(subtotal * TAX_RATE);
+}
+
+async function createOrderDoc(params: {
+  items: CartItem[];
+  fulfillmentType: FulfillmentType;
+  locationId: string;
+  customerEmail: string | undefined;
+  subtotal: number;
+  tax: number;
+  total: number;
+}): Promise<string> {
+  const db = getFirestore();
+  const now = new Date();
+  const docRef = db.collection('orders').doc();
+  await docRef.set({
+    items: params.items.map(item => ({
+      productId: item.productId,
+      productName: item.productName,
+      quantity: item.quantity,
+      unitPrice: item.unitPrice,
+      lineTotal: item.unitPrice * item.quantity,
+    })),
+    subtotal: params.subtotal,
+    tax: params.tax,
+    total: params.total,
+    locationId: params.locationId,
+    fulfillmentType: params.fulfillmentType,
+    status: 'pending' as OrderStatus,
+    customerEmail: params.customerEmail ?? null,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return docRef.id;
+}
+
+async function patchOrderStatus(
+  orderId: string,
+  status: OrderStatus,
+  reddeTxnId?: string
+): Promise<void> {
+  const db = getFirestore();
+  const patch: Record<string, unknown> = { status, updatedAt: new Date() };
+  if (reddeTxnId !== undefined) {
+    patch.reddeTxnId = reddeTxnId;
+  }
+  await db.collection('orders').doc(orderId).update(patch);
+}
+
+async function callReddeInitiate(
+  apiKey: string,
+  payload: ReddeInitiatePayload
+): Promise<ReddeInitiateResponse> {
+  const url = `${REDDE_BASE_URL}${REDDE_INITIATE_PATH}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      // TODO(#63): Confirm auth header name (Bearer vs custom header).
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+
+  const json = (await response.json()) as Partial<ReddeInitiateResponse> & {
+    message?: string;
+  };
+
+  if (!response.ok || !json.txnId || !json.paymentUrl) {
+    throw new Error(
+      json.message ?? `Redde API error (HTTP ${response.status})`
+    );
+  }
+
+  return json as ReddeInitiateResponse;
+}
+
+// ── Exported Cloud Function ───────────────────────────────────────────────────
+
+export const initiatePayment = onCall<
+  InitiatePaymentRequest,
+  Promise<InitiatePaymentResponse>
+>(
+  {
+    secrets: [REDDE_API_KEY],
+    region: 'us-central1',
+  },
+  async request => {
+    const { items, fulfillmentType, locationId, customerEmail } = request.data;
+
+    // ── Validate ──────────────────────────────────────────────────────────
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new HttpsError(
+        'invalid-argument',
+        'items must be a non-empty array'
+      );
+    }
+
+    for (const item of items) {
+      if (
+        typeof item.productId !== 'string' ||
+        typeof item.productName !== 'string' ||
+        typeof item.quantity !== 'number' ||
+        item.quantity < 1 ||
+        typeof item.unitPrice !== 'number' ||
+        item.unitPrice <= 0
+      ) {
+        throw new HttpsError(
+          'invalid-argument',
+          'Each item must have productId, productName, quantity >= 1, and unitPrice > 0'
+        );
+      }
+    }
+
+    if (fulfillmentType !== 'pickup' && fulfillmentType !== 'shipping') {
+      throw new HttpsError(
+        'invalid-argument',
+        'fulfillmentType must be "pickup" or "shipping"'
+      );
+    }
+
+    if (typeof locationId !== 'string' || !locationId) {
+      throw new HttpsError('invalid-argument', 'locationId is required');
+    }
+
+    // ── Compute totals ────────────────────────────────────────────────────
+    const subtotal = calcSubtotal(items);
+    const tax = calcTax(subtotal);
+    const total = subtotal + tax;
+
+    // ── Create order BEFORE calling Redde (ensures record on API failure) ─
+    let orderId: string;
+    try {
+      orderId = await createOrderDoc({
+        items,
+        fulfillmentType,
+        locationId,
+        customerEmail,
+        subtotal,
+        tax,
+        total,
+      });
+    } catch (err) {
+      logger.error('[initiatePayment] Failed to create order doc', { err });
+      throw new HttpsError('internal', 'Failed to create order');
+    }
+
+    const apiKey = REDDE_API_KEY.value();
+    if (!apiKey) {
+      logger.error('[initiatePayment] REDDE_API_KEY is not set');
+      await patchOrderStatus(orderId, 'failed');
+      throw new HttpsError('internal', 'Payment service not configured');
+    }
+
+    // ── Call Redde API ────────────────────────────────────────────────────
+    // TODO(#63): Adjust successUrl / cancelUrl if base domain changes.
+    const appBaseUrl = process.env.APP_BASE_URL ?? 'https://rush-n-relax.com';
+    const payload: ReddeInitiatePayload = {
+      amount: total, // TODO(#63): Confirm cents vs dollars with Redde docs
+      currency: 'USD',
+      orderId,
+      description: 'Rush N Relax order',
+      callbackUrl: `${appBaseUrl}/api/redde/webhook`,
+      successUrl: `${appBaseUrl}/order/${orderId}`,
+      cancelUrl: `${appBaseUrl}/cart`,
+      ...(customerEmail ? { customerEmail } : {}),
+    };
+
+    try {
+      const reddeResponse = await callReddeInitiate(apiKey, payload);
+      await patchOrderStatus(orderId, 'pending', reddeResponse.txnId);
+      logger.info('[initiatePayment] Transaction initiated', {
+        orderId,
+        reddeTxnId: reddeResponse.txnId,
+      });
+      return { orderId, paymentUrl: reddeResponse.paymentUrl };
+    } catch (err) {
+      logger.error('[initiatePayment] Redde API call failed', { orderId, err });
+      await patchOrderStatus(orderId, 'failed');
+      throw new HttpsError(
+        'unavailable',
+        'Payment initiation failed. Please try again.'
+      );
+    }
+  }
+);

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -12,5 +12,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "compileOnSave": true,
-  "include": ["index.ts"]
+  "include": ["index.ts", "initiatePayment.ts"]
 }

--- a/src/app/(storefront)/cart/CartPage.tsx
+++ b/src/app/(storefront)/cart/CartPage.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useCart } from '@/hooks/useCart';
+import { callFunction } from '@/firebase';
+import { formatCents } from '@/utils/currency';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Mirrors InitiatePaymentRequest from functions/initiatePayment.ts */
+interface InitiatePaymentRequest {
+  items: {
+    productId: string;
+    productName: string;
+    quantity: number;
+    unitPrice: number;
+  }[];
+  fulfillmentType: 'pickup' | 'shipping';
+  locationId: string;
+  customerEmail?: string;
+}
+
+interface InitiatePaymentResponse {
+  orderId: string;
+  paymentUrl: string;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+type FulfillmentType = 'pickup' | 'ship';
+
+const PICKUP_LOCATIONS = [
+  { id: 'oak-ridge', name: 'Oak Ridge' },
+  { id: 'maryville', name: 'Maryville' },
+  { id: 'seymour', name: 'Seymour' },
+] as const;
+
+// Flat TN tax placeholder — real tax computed server-side at initiatePayment.
+const TAX_RATE = 0.0925;
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function CartPage() {
+  const router = useRouter();
+  const { items, removeItem, updateQty, total, clearCart } = useCart();
+
+  const [fulfillment, setFulfillment] = useState<FulfillmentType | null>(null);
+  const [pickupLocation, setPickupLocation] = useState<string>('');
+  const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+
+  const hasOnlineItems = items.some(() => true);
+
+  const canCheckout =
+    !isCheckingOut &&
+    (fulfillment === 'ship' ||
+      (fulfillment === 'pickup' && pickupLocation !== ''));
+
+  // ── Age gate compliance: user must have accepted the age gate. ──────────────
+  // The age gate sets a localStorage/cookie value. The gate itself wraps the
+  // app layout — if a user reaches /cart they have already passed the gate.
+  // No additional check needed here beyond what the AgeGate layout enforces.
+
+  const handleCheckout = async () => {
+    if (!canCheckout || !fulfillment) return;
+    setIsCheckingOut(true);
+    setCheckoutError(null);
+
+    try {
+      const locationId =
+        fulfillment === 'pickup' ? pickupLocation : 'online';
+
+      const result = await callFunction<
+        InitiatePaymentRequest,
+        InitiatePaymentResponse
+      >('initiatePayment')({
+        items: items.map(item => ({
+          productId: item.productId,
+          productName: item.productName,
+          quantity: item.quantity,
+          unitPrice: item.unitPrice,
+        })),
+        fulfillmentType: fulfillment === 'ship' ? 'shipping' : 'pickup',
+        locationId,
+      });
+
+      // Redirect to Redde-hosted payment page in the same tab.
+      // Cart is NOT cleared here — cleared only after confirmed paid event.
+      router.push(result.paymentUrl);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Something went wrong. Please try again.';
+      setCheckoutError(message);
+      setIsCheckingOut(false);
+    }
+  };
+
+  if (items.length === 0) {
+    return (
+      <main className="cart-page">
+        <div className="container">
+          <h1>Your Cart</h1>
+          <div className="cart-empty">
+            <p>Your cart is empty.</p>
+            <Link href="/products" className="btn btn-primary">
+              Browse Products
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const taxEstimate = Math.round(total * TAX_RATE);
+
+  return (
+    <main className="cart-page">
+      <div className="container">
+        <h1>Your Cart</h1>
+
+        <div className="cart-layout">
+          {/* ── Cart Table ──────────────────────────────────────── */}
+          <section className="cart-items-section" aria-label="Cart items">
+            <table className="cart-table">
+              <thead>
+                <tr>
+                  <th>Product</th>
+                  <th>Price</th>
+                  <th>Qty</th>
+                  <th>Total</th>
+                  <th>
+                    <span className="sr-only">Remove</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map(item => (
+                  <tr key={item.productId}>
+                    <td>
+                      <Link href={`/products/${item.productSlug}`}>
+                        {item.productName}
+                      </Link>
+                    </td>
+                    <td>{formatCents(item.unitPrice)}</td>
+                    <td>
+                      <div className="cart-qty-controls">
+                        <button
+                          type="button"
+                          className="cart-qty-btn"
+                          aria-label={`Decrease quantity of ${item.productName}`}
+                          onClick={() =>
+                            item.quantity === 1
+                              ? removeItem(item.productId)
+                              : updateQty(item.productId, item.quantity - 1)
+                          }
+                        >
+                          −
+                        </button>
+                        <span>{item.quantity}</span>
+                        <button
+                          type="button"
+                          className="cart-qty-btn"
+                          aria-label={`Increase quantity of ${item.productName}`}
+                          onClick={() =>
+                            updateQty(item.productId, item.quantity + 1)
+                          }
+                        >
+                          +
+                        </button>
+                      </div>
+                    </td>
+                    <td>{formatCents(item.unitPrice * item.quantity)}</td>
+                    <td>
+                      <button
+                        type="button"
+                        className="cart-remove-btn"
+                        aria-label={`Remove ${item.productName}`}
+                        onClick={() => removeItem(item.productId)}
+                      >
+                        ×
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+
+          {/* ── Order Summary + Fulfillment ──────────────────────── */}
+          <aside className="cart-summary">
+            <h2>Order Summary</h2>
+            <dl className="cart-summary-lines">
+              <div className="cart-summary-row">
+                <dt>Subtotal</dt>
+                <dd>{formatCents(total)}</dd>
+              </div>
+              <div className="cart-summary-row">
+                <dt>Estimated Tax</dt>
+                <dd>{formatCents(taxEstimate)}</dd>
+              </div>
+              <div className="cart-summary-row cart-summary-total">
+                <dt>Estimated Total</dt>
+                <dd>{formatCents(total + taxEstimate)}</dd>
+              </div>
+            </dl>
+
+            {/* Fulfillment Selector */}
+            <fieldset className="cart-fulfillment">
+              <legend>How would you like your order?</legend>
+              <label className="cart-fulfillment-option">
+                <input
+                  type="radio"
+                  name="fulfillment"
+                  value="pickup"
+                  checked={fulfillment === 'pickup'}
+                  onChange={() => setFulfillment('pickup')}
+                />
+                Pickup
+              </label>
+              {hasOnlineItems && (
+                <label className="cart-fulfillment-option">
+                  <input
+                    type="radio"
+                    name="fulfillment"
+                    value="ship"
+                    checked={fulfillment === 'ship'}
+                    onChange={() => setFulfillment('ship')}
+                  />
+                  Ship to me
+                </label>
+              )}
+            </fieldset>
+
+            {fulfillment === 'pickup' && (
+              <div className="cart-pickup-location">
+                <label htmlFor="pickup-location">Select location</label>
+                <select
+                  id="pickup-location"
+                  value={pickupLocation}
+                  onChange={e => setPickupLocation(e.target.value)}
+                >
+                  <option value="">— Choose a location —</option>
+                  {PICKUP_LOCATIONS.map(loc => (
+                    <option key={loc.id} value={loc.id}>
+                      {loc.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <button
+              type="button"
+              className="btn btn-primary cart-checkout-btn"
+              disabled={!canCheckout}
+              aria-disabled={!canCheckout}
+              onClick={handleCheckout}
+            >
+              {isCheckingOut ? 'Processing…' : 'Proceed to Checkout'}
+            </button>
+
+            {checkoutError && (
+              <p className="cart-checkout-error" role="alert">
+                {checkoutError}
+              </p>
+            )}
+
+            <button
+              type="button"
+              className="cart-clear-btn"
+              onClick={clearCart}
+              disabled={isCheckingOut}
+            >
+              Clear cart
+            </button>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(storefront)/cart/page.tsx
+++ b/src/app/(storefront)/cart/page.tsx
@@ -1,0 +1,10 @@
+import { Metadata } from 'next';
+import CartPage from './CartPage';
+
+export const metadata: Metadata = {
+  title: 'Your Cart — Rush N Relax',
+};
+
+export default function CartRoute() {
+  return <CartPage />;
+}

--- a/src/app/api/redde/webhook/route.test.ts
+++ b/src/app/api/redde/webhook/route.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for Redde webhook handler.
+ * Mocks updateOrderStatus — never hits Firestore.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'crypto';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockUpdateOrderStatus = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/repositories/order.repository', () => ({
+  updateOrderStatus: mockUpdateOrderStatus,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const WEBHOOK_SECRET = 'test-webhook-secret';
+
+function sign(body: string): string {
+  const digest = createHmac('sha256', WEBHOOK_SECRET).update(body).digest('hex');
+  return `sha256=${digest}`;
+}
+
+function makeRequest(body: unknown, sig?: string | null): Request {
+  const bodyStr = JSON.stringify(body);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (sig !== null) {
+    headers['x-redde-signature'] = sig ?? sign(bodyStr);
+  }
+  return new Request('http://localhost/api/redde/webhook', {
+    method: 'POST',
+    headers,
+    body: bodyStr,
+  });
+}
+
+function paidEvent(orderId = 'ord-123', txnId = 'rde_txn_abc') {
+  return { event: 'payment.paid', txnId, orderId, amount: 4999, currency: 'USD' };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/redde/webhook', () => {
+  let POST: (req: Request) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubEnv('REDDE_WEBHOOK_SECRET', WEBHOOK_SECRET);
+    const mod = await import('./route');
+    POST = mod.POST;
+  });
+
+  describe('signature verification', () => {
+    it('returns 401 for requests with no signature header', async () => {
+      const res = await POST(makeRequest(paidEvent(), null));
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 for requests with an invalid signature', async () => {
+      const res = await POST(makeRequest(paidEvent(), 'sha256=badhex'));
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 200 for requests with a valid signature', async () => {
+      const res = await POST(makeRequest(paidEvent()));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('event handling', () => {
+    it('updates order to "paid" on payment.paid', async () => {
+      await POST(makeRequest(paidEvent('ord-1', 'txn-1')));
+      expect(mockUpdateOrderStatus).toHaveBeenCalledWith('ord-1', 'paid', 'txn-1');
+    });
+
+    it('updates order to "failed" on payment.failed', async () => {
+      const body = { event: 'payment.failed', txnId: 'txn-2', orderId: 'ord-2' };
+      await POST(makeRequest(body));
+      expect(mockUpdateOrderStatus).toHaveBeenCalledWith('ord-2', 'failed', 'txn-2');
+    });
+
+    it('updates order to "voided" on payment.voided', async () => {
+      const body = { event: 'payment.voided', txnId: 'txn-3', orderId: 'ord-3' };
+      await POST(makeRequest(body));
+      expect(mockUpdateOrderStatus).toHaveBeenCalledWith('ord-3', 'voided', 'txn-3');
+    });
+
+    it('updates order to "refunded" on payment.refunded', async () => {
+      const body = { event: 'payment.refunded', txnId: 'txn-4', orderId: 'ord-4' };
+      await POST(makeRequest(body));
+      expect(mockUpdateOrderStatus).toHaveBeenCalledWith('ord-4', 'refunded', 'txn-4');
+    });
+
+    it('returns 200 without calling updateOrderStatus for unknown event types', async () => {
+      const body = { event: 'payment.unknown', txnId: 'txn-5', orderId: 'ord-5' };
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(200);
+      expect(mockUpdateOrderStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 (idempotent) when same event processed twice', async () => {
+      const event = paidEvent('ord-6', 'txn-6');
+      await POST(makeRequest(event));
+      const res = await POST(makeRequest(event));
+      expect(res.status).toBe(200);
+      expect(mockUpdateOrderStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 400 if orderId is missing', async () => {
+      const body = { event: 'payment.paid', txnId: 'txn-7' };
+      const res = await POST(makeRequest(body));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 500 and does not swallow if updateOrderStatus throws', async () => {
+      mockUpdateOrderStatus.mockRejectedValueOnce(new Error('Firestore error'));
+      const res = await POST(makeRequest(paidEvent('ord-8', 'txn-8')));
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/redde/webhook/route.ts
+++ b/src/app/api/redde/webhook/route.ts
@@ -1,0 +1,147 @@
+/**
+ * Redde Payments webhook handler
+ * POST /api/redde/webhook
+ *
+ * Receives payment status events from Redde and updates the corresponding
+ * order document in Firestore.
+ *
+ * Depends on:
+ *   - #63 Redde API docs (signature header name and algorithm — TODO below)
+ *   - #64 orders repository (updateOrderStatus imported from expected path)
+ *
+ * Environment variable required: REDDE_WEBHOOK_SECRET
+ *   Set in Vercel environment variables.
+ */
+
+import { createHmac, timingSafeEqual } from 'crypto';
+import { updateOrderStatus } from '@/lib/repositories/order.repository';
+import type { OrderStatus } from '@/types/order';
+
+// TODO(#63): Confirm signature header name from Redde developer portal.
+const SIGNATURE_HEADER = 'x-redde-signature';
+const HASH_ALGO = 'sha256';
+
+// ── Redde event types ─────────────────────────────────────────────────────────
+
+/** Subset of known Redde event names. TODO(#63): confirm exact strings. */
+type ReddeEventType =
+  | 'payment.paid'
+  | 'payment.failed'
+  | 'payment.voided'
+  | 'payment.refunded';
+
+interface ReddeWebhookPayload {
+  event: string;
+  txnId: string;
+  orderId: string;
+  amount?: number;
+  currency?: string;
+  [key: string]: unknown;
+}
+
+// ── Event → OrderStatus mapping ───────────────────────────────────────────────
+
+const EVENT_TO_STATUS: Partial<Record<ReddeEventType, OrderStatus>> = {
+  'payment.paid': 'paid',
+  'payment.failed': 'failed',
+  'payment.voided': 'voided',
+  'payment.refunded': 'refunded',
+};
+
+// ── Signature verification ────────────────────────────────────────────────────
+
+/**
+ * Verify HMAC-SHA256 signature.
+ * TODO(#63): Confirm format is `sha256=<hex>` once Redde docs confirmed.
+ */
+function verifySignature(
+  rawBody: Buffer,
+  signatureHeader: string | null,
+  secret: string
+): boolean {
+  if (!signatureHeader) return false;
+
+  const [algo, digest] = signatureHeader.split('=');
+  if (algo !== HASH_ALGO || !digest) return false;
+
+  const expected = createHmac(HASH_ALGO, secret).update(rawBody).digest('hex');
+
+  try {
+    const digestBuf = Buffer.from(digest, 'hex');
+    const expectedBuf = Buffer.from(expected, 'hex');
+    if (digestBuf.length !== expectedBuf.length) return false;
+    return timingSafeEqual(digestBuf, expectedBuf);
+  } catch {
+    return false;
+  }
+}
+
+// ── Route handler ─────────────────────────────────────────────────────────────
+
+export async function POST(request: Request): Promise<Response> {
+  const rawBody = Buffer.from(await request.arrayBuffer());
+
+  const webhookSecret = process.env.REDDE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.error('[redde/webhook] REDDE_WEBHOOK_SECRET is not set');
+    // Return 200 to avoid Redde retrying when misconfigured server-side.
+    return new Response(null, { status: 200 });
+  }
+
+  const signatureHeader = request.headers.get(SIGNATURE_HEADER);
+  if (!verifySignature(rawBody, signatureHeader, webhookSecret)) {
+    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let payload: ReddeWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody.toString('utf-8')) as ReddeWebhookPayload;
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { event, txnId, orderId } = payload;
+
+  if (!orderId) {
+    console.warn('[redde/webhook] Received event without orderId', { event, txnId });
+    return new Response(null, { status: 400 });
+  }
+
+  const newStatus = EVENT_TO_STATUS[event as ReddeEventType];
+
+  if (!newStatus) {
+    // Log unrecognized events but return 200 — Redde must not keep retrying.
+    console.warn('[redde/webhook] Unrecognized event type', { event, orderId });
+    return new Response(null, { status: 200 });
+  }
+
+  try {
+    // Idempotent: updateOrderStatus sets status + updatedAt regardless of
+    // current value — calling twice with the same status is harmless.
+    await updateOrderStatus(orderId, newStatus, txnId);
+    console.info('[redde/webhook] Order status updated', {
+      orderId,
+      event,
+      newStatus,
+    });
+  } catch (err) {
+    console.error('[redde/webhook] Failed to update order status', {
+      orderId,
+      event,
+      err,
+    });
+    // Return 500 so Redde retries — we want to process the event eventually.
+    return new Response(
+      JSON.stringify({ error: 'Failed to update order' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  return new Response(null, { status: 200 });
+}


### PR DESCRIPTION
Closes #63, Closes #65, Closes #66, Closes #73

## Per-Issue Summary

### #63 — Redde Payments API documentation
Created \`docs/engineering/redde-api.md\` with scaffolded API contract based on publicly available patterns. Includes: auth header format, initiate/void/refund endpoints with request/response shapes, HMAC webhook signature verification algorithm, and four webhook event payload examples (\`payment.paid\`, \`payment.failed\`, \`payment.voided\`, \`payment.refunded\`). All fields that require KB to verify against the authenticated developer portal are marked **KB TO VERIFY**.

### #65 — \`initiatePayment\` Cloud Function
Added \`functions/initiatePayment.ts\` — a v2 callable Cloud Function that validates cart items, creates an \`orders/{id}\` doc with \`status: pending\` before calling Redde (so a record exists even on API failure), calls the Redde initiate endpoint, updates the order with \`reddeTxnId\`, and returns \`{ orderId, paymentUrl }\`. Fails fast with \`status: failed\` on Redde error. Secret: \`REDDE_API_KEY\`. Unit tested with mocked Firestore and fetch in \`functions/initiatePayment.test.ts\`.

**TODO stubs pending #63 confirmation:**
- Base URL (\`https://api.reddedashboard.com/v1\`) — verify
- Auth header format (\`Authorization: Bearer\`) — verify
- \`amount\` field unit (cents vs dollars) — verify

### #66 — Redde webhook handler (\`/api/redde/webhook\`)
Added \`src/app/api/redde/webhook/route.ts\` — a Next.js App Router POST handler that verifies HMAC-SHA256 signature, maps Redde event types to \`OrderStatus\`, and calls \`updateOrderStatus\`. Returns 401 for bad signatures, 400 for missing \`orderId\`, 200 for unrecognized events (no retry storm), 500 on Firestore failure (triggers Redde retry). Idempotent. Env var: \`REDDE_WEBHOOK_SECRET\`. Unit tested in \`route.test.ts\`.

**TODO stubs pending #63 confirmation:**
- Signature header name (\`x-redde-signature\`) — verify
- Event type strings (\`payment.paid\`, etc.) — verify

### #73 — Checkout button wired to \`initiatePayment\` CF
Updated \`src/app/(storefront)/cart/CartPage.tsx\` to call \`initiatePayment\` on checkout. Button shows "Processing…" and disables during the CF call. On success: \`router.push(paymentUrl)\` redirects to Redde-hosted payment page. On failure: inline error below the checkout button (no toast/alert). Cart is NOT cleared until order is confirmed \`paid\` via webhook.

## Cross-branch dependency note
Issues #65, #66, and #73 depend on \`worker/feature-cart-and-pricing\` (orders repo from #64, \`useCart\` hook from #69, \`/cart\` page from #72). A merge conflict is expected and trivial to resolve — the new files in this PR are additive and do not conflict with the order/cart types once both branches are merged.

---
Worked by: worker agent (BrewCortex)