### PR TITLE
feat: staff phone login + role-aware access control [+8 more]

### DIFF
--- a/src/__tests__/lib/jwt.test.ts
+++ b/src/__tests__/lib/jwt.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { decodeJwtPayload } from '@/lib/jwt';
+
+/** Build a minimal JWT string from a payload object (no real signature). */
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.fake-signature`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('returns parsed payload object from a valid JWT string', () => {
+    const jwt = buildJwt({ uid: 'abc', role: 'staff' });
+    const result = decodeJwtPayload(jwt);
+    expect(result).toEqual(
+      expect.objectContaining({ uid: 'abc', role: 'staff' })
+    );
+  });
+
+  it('returns null for a malformed base64 string without throwing', () => {
+    const result = decodeJwtPayload('not.valid.jwt!!!');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an empty string without throwing', () => {
+    const result = decodeJwtPayload('');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a JWT with only one segment', () => {
+    const result = decodeJwtPayload('onlyone');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when payload segment is valid base64 but not JSON', () => {
+    const garbage = btoa('not-json');
+    const result = decodeJwtPayload(`header.${garbage}.sig`);
+    expect(result).toBeNull();
+  });
+});

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/** Build a minimal JWT string from a payload object (no real signature). */
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.fake-signature`;
+}
+
+function buildRequest(pathname: string, sessionJwt?: string): NextRequest {
+  const url = `http://localhost${pathname}`;
+  const req = new NextRequest(url);
+  if (sessionJwt) {
+    req.cookies.set('__session', sessionJwt);
+  }
+  return req;
+}
+
+// Mock seoConfig to keep middleware tests focused on auth logic only
+vi.mock('@/config/seo.config', () => ({
+  seoConfig: {
+    redirects: [],
+    canonicalRules: {
+      trailingSlash: 'remove',
+      httpsEnforce: false,
+      wwwRedirect: 'non-www',
+    },
+    noindex: ['/admin'],
+  },
+}));
+
+import { middleware } from '@/middleware';
+
+describe('middleware — staff route guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects staff from /admin/users to /admin/products', () => {
+    const staffJwt = buildJwt({ role: 'staff' });
+    const req = buildRequest('/admin/users', staffJwt);
+
+    const response = middleware(req);
+
+    expect(response?.status).toBeGreaterThanOrEqual(300);
+    expect(response?.headers.get('location')).toContain('/admin/products');
+  });
+
+  it('allows staff to access /admin/products/new', () => {
+    const staffJwt = buildJwt({ role: 'staff' });
+    const req = buildRequest('/admin/products/new', staffJwt);
+
+    const response = middleware(req);
+
+    // Should not redirect to /admin/products — either next() or noindex header
+    const location = response?.headers.get('location') ?? '';
+    expect(location).not.toContain('/admin/products');
+  });
+
+  it('allows staff to access /admin/coa', () => {
+    const staffJwt = buildJwt({ role: 'staff' });
+    const req = buildRequest('/admin/coa', staffJwt);
+
+    const response = middleware(req);
+
+    const location = response?.headers.get('location') ?? '';
+    expect(location).not.toContain('/admin/products');
+  });
+
+  it('allows owner to access /admin/users without redirect', () => {
+    const ownerJwt = buildJwt({ role: 'owner' });
+    const req = buildRequest('/admin/users', ownerJwt);
+
+    const response = middleware(req);
+
+    const location = response?.headers.get('location') ?? '';
+    expect(location).not.toContain('/admin/products');
+  });
+
+  it('treats malformed JWT payload as no role — falls through to cookie-presence guard', () => {
+    // Malformed JWT — decodeJwtPayload returns null; role treated as absent.
+    // The path is an admin route and a cookie is present (so cookie-presence guard passes),
+    // but role is unknown so non-owner, non-staff treatment applies (no crash, no throw).
+    const malformedJwt = 'not.valid.jwt!!!';
+    const req = buildRequest('/admin/inventory', malformedJwt);
+
+    // Middleware should not throw
+    expect(() => middleware(req)).not.toThrow();
+  });
+});

--- a/src/app/(admin)/AdminNav.tsx
+++ b/src/app/(admin)/AdminNav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import cannabisLeaf from '@/assets/icons/cannabis-leaf.svg';
 import { getAssetSrc } from '@/utils/assetSrc';
 import LogoutButton from './admin/LogoutButton';
+import type { UserRole } from '@/types';
 
 const LEAF_SRC = getAssetSrc(cannabisLeaf);
 
@@ -27,7 +28,19 @@ const ALL_LINKS = [
   { label: '← Client Site', href: '/' },
 ] as const;
 
-export function AdminNav() {
+/** Links available to staff role (and above via the full ALL_LINKS list). */
+const STAFF_LINKS = [
+  { label: 'Products', href: '/admin/products' },
+  { label: 'Categories', href: '/admin/categories' },
+  { label: 'COA', href: '/admin/coa' },
+  { label: '← Client Site', href: '/' },
+] as const;
+
+interface AdminNavProps {
+  role: UserRole | null;
+}
+
+export function AdminNav({ role }: AdminNavProps) {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
 
@@ -40,19 +53,24 @@ export function AdminNav() {
     }
   }, [isOpen]);
 
+  const isStaffOnly = role === 'staff';
+  const drawerLinks = isStaffOnly ? STAFF_LINKS : ALL_LINKS;
+
   return (
     <div className="admin-nav">
-      <div className="admin-nav-pinned" aria-label="Pinned admin links">
-        {PINNED.map(link => (
-          <Link
-            key={link.href}
-            href={link.href}
-            className={`admin-nav-pinned-link${pathname.startsWith(link.href) ? ' admin-nav-pinned-link--active' : ''}`}
-          >
-            {link.label}
-          </Link>
-        ))}
-      </div>
+      {!isStaffOnly && (
+        <div className="admin-nav-pinned" aria-label="Pinned admin links">
+          {PINNED.map(link => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`admin-nav-pinned-link${pathname.startsWith(link.href) ? ' admin-nav-pinned-link--active' : ''}`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      )}
 
       <button
         type="button"
@@ -83,7 +101,7 @@ export function AdminNav() {
         aria-label="Full admin navigation"
       >
         <ul className="admin-nav-drawer-list">
-          {ALL_LINKS.map(link => (
+          {drawerLinks.map(link => (
             <li key={link.href}>
               <Link
                 href={link.href}

--- a/src/app/(admin)/admin/categories/[slug]/edit/actions.ts
+++ b/src/app/(admin)/admin/categories/[slug]/edit/actions.ts
@@ -10,7 +10,7 @@ export async function updateCategory(
   _prev: { error?: string } | null,
   formData: FormData
 ): Promise<{ error?: string }> {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const existing = await getCategoryBySlug(slug);
   if (!existing) return { error: 'Category not found.' };

--- a/src/app/(admin)/admin/categories/[slug]/edit/page.tsx
+++ b/src/app/(admin)/admin/categories/[slug]/edit/page.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export default async function CategoryEditPage({ params }: Props) {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const { slug } = await params;
   const category = await getCategoryBySlug(slug);

--- a/src/app/(admin)/admin/categories/actions.ts
+++ b/src/app/(admin)/admin/categories/actions.ts
@@ -8,7 +8,7 @@ export async function toggleCategoryStatus(
   slug: string,
   currentIsActive: boolean
 ): Promise<void> {
-  await requireRole('owner');
+  await requireRole('staff');
   await setCategoryStatus(slug, !currentIsActive);
   revalidatePath('/admin/categories');
   revalidatePath('/products');

--- a/src/app/(admin)/admin/categories/new/actions.ts
+++ b/src/app/(admin)/admin/categories/new/actions.ts
@@ -9,7 +9,7 @@ export async function createCategory(
   _prev: { error?: string } | null,
   formData: FormData
 ): Promise<{ error?: string }> {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const slug = formData.get('slug')?.toString().trim().toLowerCase();
   const label = formData.get('label')?.toString().trim();

--- a/src/app/(admin)/admin/categories/new/page.tsx
+++ b/src/app/(admin)/admin/categories/new/page.tsx
@@ -4,7 +4,7 @@ import { requireRole } from '@/lib/admin-auth';
 import { CategoryCreateForm } from './CategoryCreateForm';
 
 export default async function NewCategoryPage() {
-  await requireRole('owner');
+  await requireRole('staff');
 
   return (
     <>

--- a/src/app/(admin)/admin/categories/page.tsx
+++ b/src/app/(admin)/admin/categories/page.tsx
@@ -7,7 +7,7 @@ import { ConfirmButton } from '@/components/admin/ConfirmButton';
 import { toggleCategoryStatus } from './actions';
 
 export default async function AdminCategoriesPage() {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const categories = await listAllCategories();
 
@@ -45,7 +45,9 @@ export default async function AdminCategoriesPage() {
                 <td>
                   <span
                     className={
-                      cat.isActive ? 'admin-badge-active' : 'admin-badge-inactive'
+                      cat.isActive
+                        ? 'admin-badge-active'
+                        : 'admin-badge-inactive'
                     }
                   >
                     {cat.isActive ? 'Active' : 'Inactive'}

--- a/src/app/(admin)/admin/coa/actions.ts
+++ b/src/app/(admin)/admin/coa/actions.ts
@@ -107,7 +107,7 @@ export async function updateCoaLabel(
 }
 
 export async function deleteCoaDocument(formData: FormData): Promise<void> {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const name = formData.get('name')?.toString();
   if (!name || !name.startsWith(COA_PREFIX)) return;

--- a/src/app/(admin)/admin/dashboard/DashboardGrid.tsx
+++ b/src/app/(admin)/admin/dashboard/DashboardGrid.tsx
@@ -19,6 +19,7 @@ import {
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import type { UserRole } from '@/types';
 
 const STORAGE_KEY = 'admin-dashboard-order';
 
@@ -28,7 +29,7 @@ interface DashboardCard {
   href: string;
 }
 
-const DEFAULT_CARDS: DashboardCard[] = [
+const ALL_CARDS: DashboardCard[] = [
   { id: 'locations', label: 'Manage Locations', href: '/admin/locations' },
   { id: 'products', label: 'Manage Products', href: '/admin/products' },
   { id: 'categories', label: 'Manage Categories', href: '/admin/categories' },
@@ -47,6 +48,14 @@ const DEFAULT_CARDS: DashboardCard[] = [
   },
   { id: 'coa', label: 'Certificates of Analysis', href: '/admin/coa' },
 ];
+
+/** Card IDs available to the staff role — mirrors STAFF_LINKS in AdminNav. */
+const STAFF_CARD_IDS = new Set(['products', 'categories', 'coa']);
+
+function getDefaultCards(role: UserRole): DashboardCard[] {
+  if (role === 'staff') return ALL_CARDS.filter(c => STAFF_CARD_IDS.has(c.id));
+  return ALL_CARDS;
+}
 
 function loadOrder(): string[] | null {
   try {
@@ -118,15 +127,20 @@ function SortableCard({ card }: { card: DashboardCard }) {
   );
 }
 
-export function DashboardGrid() {
-  const [cards, setCards] = useState<DashboardCard[]>(DEFAULT_CARDS);
+interface DashboardGridProps {
+  role: UserRole;
+}
+
+export function DashboardGrid({ role }: DashboardGridProps) {
+  const defaultCards = getDefaultCards(role);
+  const [cards, setCards] = useState<DashboardCard[]>(defaultCards);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- client-mount guard; localStorage not available on server
     setMounted(true);
     const saved = loadOrder();
-    if (saved) setCards(applyOrder(DEFAULT_CARDS, saved));
+    if (saved) setCards(applyOrder(defaultCards, saved));
   }, []);
 
   const sensors = useSensors(

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -2,7 +2,7 @@ import { requireRole } from '@/lib/admin-auth';
 import { DashboardGrid } from './DashboardGrid';
 
 export default async function DashboardPage() {
-  await requireRole('staff');
+  const { role } = await requireRole('staff');
 
   return (
     <>
@@ -13,7 +13,7 @@ export default async function DashboardPage() {
         Control locations, products, promos, and inventory from one workspace.
         Drag cards to arrange your preferred layout.
       </p>
-      <DashboardGrid />
+      <DashboardGrid role={role} />
     </>
   );
 }

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -2,7 +2,7 @@ import { requireRole } from '@/lib/admin-auth';
 import { DashboardGrid } from './DashboardGrid';
 
 export default async function DashboardPage() {
-  await requireRole('owner');
+  await requireRole('staff');
 
   return (
     <>

--- a/src/app/(admin)/admin/login/page.tsx
+++ b/src/app/(admin)/admin/login/page.tsx
@@ -1,14 +1,67 @@
 'use client';
 
-import { useState, useTransition } from 'react';
-import { signInWithPopup, GoogleAuthProvider } from 'firebase/auth';
+import { useState, useTransition, useEffect, useRef } from 'react';
+import {
+  signInWithPopup,
+  GoogleAuthProvider,
+  signInWithPhoneNumber,
+  RecaptchaVerifier,
+  type ConfirmationResult,
+  type Auth,
+} from 'firebase/auth';
 import { initializeApp } from '@/firebase';
 
 const CLAIMS_UPDATED_RETRY_CODE = 'CLAIMS_UPDATED_RETRY';
 
+/** Basic E.164 format validation: +<country code><number>, 7–15 digits total */
+function isValidE164(phone: string): boolean {
+  return /^\+[1-9]\d{6,14}$/.test(phone);
+}
+
+async function exchangeTokenForSession(
+  idToken: string,
+  user: { getIdToken: (force: boolean) => Promise<string> }
+): Promise<Response> {
+  let response = await fetch('/api/auth/session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ idToken }),
+  });
+
+  if (response.status === 409) {
+    const body = (await response.json()) as { code?: unknown };
+    if (body.code === CLAIMS_UPDATED_RETRY_CODE) {
+      const refreshedToken = await user.getIdToken(true);
+      response = await fetch('/api/auth/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ idToken: refreshedToken }),
+      });
+    }
+  }
+
+  return response;
+}
+
 export default function LoginPage() {
+  const [tab, setTab] = useState<'google' | 'phone'>('google');
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+
+  // Phone flow state
+  const [phone, setPhone] = useState('');
+  const [otpStep, setOtpStep] = useState(false);
+  const [otp, setOtp] = useState('');
+  const confirmationRef = useRef<ConfirmationResult | null>(null);
+  const recaptchaRef = useRef<RecaptchaVerifier | null>(null);
+  const authRef = useRef<Auth | null>(null);
+
+  // Clean up reCAPTCHA on unmount
+  useEffect(() => {
+    return () => {
+      recaptchaRef.current?.clear();
+    };
+  }, []);
 
   function handleGoogleSignIn() {
     setError(null);
@@ -21,22 +74,88 @@ export default function LoginPage() {
         const credential = await signInWithPopup(auth, provider);
         const idToken = await credential.user.getIdToken();
 
-        let response = await fetch('/api/auth/session', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ idToken }),
-        });
+        const response = await exchangeTokenForSession(
+          idToken,
+          credential.user
+        );
 
-        if (response.status === 409) {
-          const body = (await response.json()) as { code?: unknown };
-          if (body.code === CLAIMS_UPDATED_RETRY_CODE) {
-            const refreshedToken = await credential.user.getIdToken(true);
-            response = await fetch('/api/auth/session', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ idToken: refreshedToken }),
-            });
-          }
+        if (!response.ok) {
+          throw new Error(
+            'Unable to establish admin session. Please try again.'
+          );
+        }
+
+        window.location.assign('/admin/dashboard');
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Sign-in failed. Please try again.';
+        setError(message);
+      }
+    });
+  }
+
+  function handleSendOtp() {
+    if (!isValidE164(phone)) {
+      setError(
+        'Enter a valid phone number in E.164 format (e.g. +12345678900).'
+      );
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      try {
+        const { auth } = initializeApp();
+        if (!auth) throw new Error('Auth not initialized.');
+        authRef.current = auth;
+
+        // Re-use existing verifier or create a new one
+        if (!recaptchaRef.current) {
+          recaptchaRef.current = new RecaptchaVerifier(
+            auth,
+            'recaptcha-container',
+            { size: 'invisible' }
+          );
+        }
+
+        const result = await signInWithPhoneNumber(
+          auth,
+          phone,
+          recaptchaRef.current
+        );
+        confirmationRef.current = result;
+        setOtpStep(true);
+      } catch (err: unknown) {
+        recaptchaRef.current?.clear();
+        recaptchaRef.current = null;
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Failed to send OTP. Please try again.';
+        setError(message);
+      }
+    });
+  }
+
+  function handleConfirmOtp() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const confirmation = confirmationRef.current;
+        if (!confirmation) throw new Error('No OTP session. Please resend.');
+
+        const credential = await confirmation.confirm(otp);
+        const idToken = await credential.user.getIdToken();
+
+        const response = await exchangeTokenForSession(
+          idToken,
+          credential.user
+        );
+
+        if (response.status === 403) {
+          setError('You are not authorized to access this panel.');
+          return;
         }
 
         if (!response.ok) {
@@ -45,8 +164,6 @@ export default function LoginPage() {
           );
         }
 
-        // Hard navigation so the browser commits the Set-Cookie before the
-        // middleware auth check runs (soft router.push fires too fast).
         window.location.assign('/admin/dashboard');
       } catch (err: unknown) {
         const message =
@@ -61,19 +178,123 @@ export default function LoginPage() {
   return (
     <div className="admin-login-wrap">
       <h1>Admin Login</h1>
+
+      <div className="admin-login-tabs" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'google'}
+          onClick={() => {
+            setTab('google');
+            setError(null);
+          }}
+          className={`admin-login-tab${tab === 'google' ? ' active' : ''}`}
+        >
+          Google
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'phone'}
+          onClick={() => {
+            setTab('phone');
+            setError(null);
+          }}
+          className={`admin-login-tab${tab === 'phone' ? ' active' : ''}`}
+        >
+          Phone
+        </button>
+      </div>
+
       {error && (
         <p role="alert" className="admin-error">
           {error}
         </p>
       )}
-      <button
-        type="button"
-        onClick={handleGoogleSignIn}
-        disabled={isPending}
-        className="admin-submit"
-      >
-        {isPending ? 'Signing in…' : 'Sign in with Google'}
-      </button>
+
+      {tab === 'google' && (
+        <button
+          type="button"
+          onClick={handleGoogleSignIn}
+          disabled={isPending}
+          className="admin-submit"
+        >
+          {isPending ? 'Signing in…' : 'Sign in with Google'}
+        </button>
+      )}
+
+      {tab === 'phone' && !otpStep && (
+        <div className="admin-phone-form">
+          <label htmlFor="phone-input" className="admin-label">
+            Phone number (E.164 format)
+          </label>
+          <input
+            id="phone-input"
+            type="tel"
+            value={phone}
+            onChange={e => setPhone(e.target.value)}
+            placeholder="+12345678900"
+            className="admin-input"
+            disabled={isPending}
+            autoComplete="tel"
+          />
+          <button
+            type="button"
+            onClick={handleSendOtp}
+            disabled={isPending || phone.length === 0}
+            className="admin-submit"
+          >
+            {isPending ? 'Sending…' : 'Send OTP'}
+          </button>
+        </div>
+      )}
+
+      {tab === 'phone' && otpStep && (
+        <div className="admin-phone-form">
+          <p className="admin-label">
+            Enter the code sent to <strong>{phone}</strong>
+          </p>
+          <label htmlFor="otp-input" className="admin-label">
+            One-time code
+          </label>
+          <input
+            id="otp-input"
+            type="text"
+            inputMode="numeric"
+            value={otp}
+            onChange={e => setOtp(e.target.value)}
+            placeholder="123456"
+            className="admin-input"
+            disabled={isPending}
+            autoComplete="one-time-code"
+          />
+          <button
+            type="button"
+            onClick={handleConfirmOtp}
+            disabled={isPending || otp.length === 0}
+            className="admin-submit"
+          >
+            {isPending ? 'Verifying…' : 'Verify'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setOtpStep(false);
+              setOtp('');
+              setError(null);
+              recaptchaRef.current?.clear();
+              recaptchaRef.current = null;
+            }}
+            className="admin-link-btn"
+            disabled={isPending}
+          >
+            Back
+          </button>
+        </div>
+      )}
+
+      {/* Invisible reCAPTCHA anchor — always rendered so the verifier can attach */}
+      <div id="recaptcha-container" />
     </div>
   );
 }

--- a/src/app/(admin)/admin/login/page.tsx
+++ b/src/app/(admin)/admin/login/page.tsx
@@ -13,9 +13,14 @@ import { initializeApp } from '@/firebase';
 
 const CLAIMS_UPDATED_RETRY_CODE = 'CLAIMS_UPDATED_RETRY';
 
-/** Basic E.164 format validation: +<country code><number>, 7–15 digits total */
-function isValidE164(phone: string): boolean {
-  return /^\+[1-9]\d{6,14}$/.test(phone);
+/** Validates a raw 10-digit US phone number */
+function isValidUsPhone(phone: string): boolean {
+  return /^\d{10}$/.test(phone);
+}
+
+/** Converts a 10-digit input to E.164 US format */
+function toE164(phone: string): string {
+  return `+1${phone}`;
 }
 
 async function exchangeTokenForSession(
@@ -97,10 +102,8 @@ export default function LoginPage() {
   }
 
   function handleSendOtp() {
-    if (!isValidE164(phone)) {
-      setError(
-        'Enter a valid phone number in E.164 format (e.g. +12345678900).'
-      );
+    if (!isValidUsPhone(phone)) {
+      setError('Enter a valid 10-digit US phone number (e.g. 6155550123).');
       return;
     }
     setError(null);
@@ -121,7 +124,7 @@ export default function LoginPage() {
 
         const result = await signInWithPhoneNumber(
           auth,
-          phone,
+          toE164(phone),
           recaptchaRef.current
         );
         confirmationRef.current = result;
@@ -226,22 +229,29 @@ export default function LoginPage() {
       {tab === 'phone' && !otpStep && (
         <div className="admin-phone-form">
           <label htmlFor="phone-input" className="admin-label">
-            Phone number (E.164 format)
+            Phone number
           </label>
-          <input
-            id="phone-input"
-            type="tel"
-            value={phone}
-            onChange={e => setPhone(e.target.value)}
-            placeholder="+12345678900"
-            className="admin-input"
-            disabled={isPending}
-            autoComplete="tel"
-          />
+          <div className="admin-input-prefix-wrap">
+            <span className="admin-input-prefix">+1</span>
+            <input
+              id="phone-input"
+              type="tel"
+              value={phone}
+              onChange={e =>
+                setPhone(e.target.value.replace(/\D/g, '').slice(0, 10))
+              }
+              placeholder="6155550123"
+              className="admin-input"
+              disabled={isPending}
+              autoComplete="tel-national"
+              maxLength={10}
+              inputMode="numeric"
+            />
+          </div>
           <button
             type="button"
             onClick={handleSendOtp}
-            disabled={isPending || phone.length === 0}
+            disabled={isPending || phone.length !== 10}
             className="admin-submit"
           >
             {isPending ? 'Sending…' : 'Send OTP'}
@@ -252,7 +262,7 @@ export default function LoginPage() {
       {tab === 'phone' && otpStep && (
         <div className="admin-phone-form">
           <p className="admin-label">
-            Enter the code sent to <strong>{phone}</strong>
+            Enter the code sent to <strong>+1 {phone}</strong>
           </p>
           <label htmlFor="otp-input" className="admin-label">
             One-time code

--- a/src/app/(admin)/admin/products/[slug]/edit/actions.ts
+++ b/src/app/(admin)/admin/products/[slug]/edit/actions.ts
@@ -22,7 +22,7 @@ export async function updateProduct(
   _prev: { error?: string } | null,
   formData: FormData
 ): Promise<{ error?: string }> {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const existing = await getProductBySlug(slug);
   if (!existing) return { error: 'Product not found.' };
@@ -61,8 +61,7 @@ export async function updateProduct(
     description,
     details,
     image: featuredImagePath ?? existing.image,
-    images:
-      galleryImagePaths.length > 0 ? galleryImagePaths : existing.images,
+    images: galleryImagePaths.length > 0 ? galleryImagePaths : existing.images,
     status,
     federalDeadlineRisk,
     availableAt,

--- a/src/app/(admin)/admin/products/[slug]/edit/page.tsx
+++ b/src/app/(admin)/admin/products/[slug]/edit/page.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export default async function ProductEditPage({ params }: Props) {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const { slug } = await params;
   const [product, locations, categories] = await Promise.all([

--- a/src/app/(admin)/admin/products/actions.ts
+++ b/src/app/(admin)/admin/products/actions.ts
@@ -5,7 +5,7 @@ import { requireRole } from '@/lib/admin-auth';
 import { setProductStatus } from '@/lib/repositories';
 
 export async function archiveProduct(slug: string): Promise<void> {
-  await requireRole('owner');
+  await requireRole('staff');
   await setProductStatus(slug, 'archived');
   revalidatePath('/admin/products');
   revalidatePath('/products');
@@ -13,7 +13,7 @@ export async function archiveProduct(slug: string): Promise<void> {
 }
 
 export async function restoreProduct(slug: string): Promise<void> {
-  await requireRole('owner');
+  await requireRole('staff');
   await setProductStatus(slug, 'active');
   revalidatePath('/admin/products');
   revalidatePath('/products');

--- a/src/app/(admin)/admin/products/new/actions.ts
+++ b/src/app/(admin)/admin/products/new/actions.ts
@@ -13,7 +13,7 @@ export async function createProduct(
   _prev: { error?: string } | null,
   formData: FormData
 ): Promise<{ error?: string }> {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const slug = formData.get('slug')?.toString().trim().toLowerCase();
   const name = formData.get('name')?.toString().trim();

--- a/src/app/(admin)/admin/products/new/page.tsx
+++ b/src/app/(admin)/admin/products/new/page.tsx
@@ -5,7 +5,7 @@ import { listLocations, listActiveCategories } from '@/lib/repositories';
 import { ProductCreateForm } from './ProductCreateForm';
 
 export default async function NewProductPage() {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const [locations, categories] = await Promise.all([
     listLocations(),

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -7,7 +7,7 @@ import { ConfirmButton } from '@/components/admin/ConfirmButton';
 import { archiveProduct, restoreProduct } from './actions';
 
 export default async function AdminProductsPage() {
-  await requireRole('owner');
+  await requireRole('staff');
 
   const products = await listAllProducts();
 

--- a/src/app/(admin)/admin/users/StaffPhoneForm.tsx
+++ b/src/app/(admin)/admin/users/StaffPhoneForm.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 import { useActionState } from 'react';
-import { provisionStaffPhone, revokeStaffPhone } from './actions';
+import {
+  provisionStaffPhone,
+  revokeStaffPhone,
+  setStaffDisplayName,
+} from './actions';
 
 interface StaffPhoneUser {
   uid: string;
   phoneNumber: string;
+  displayName: string;
 }
 
 interface Props {
@@ -19,6 +24,40 @@ function maskPhone(phone: string): string {
   const last2 = digits.slice(-2);
   const areaCode = digits.slice(-10, -7);
   return `+1 (${areaCode}) ***-**${last2}`;
+}
+
+function DisplayNameCell({ user }: { user: StaffPhoneUser }) {
+  const [state, action, pending] = useActionState(setStaffDisplayName, null);
+
+  return (
+    <td>
+      <form action={action} className="admin-inline-form">
+        <input type="hidden" name="uid" value={user.uid} />
+        <input
+          name="displayName"
+          type="text"
+          defaultValue={user.displayName}
+          placeholder="Add name…"
+          className="admin-input admin-input--inline"
+          disabled={pending}
+          aria-label={`Display name for ${maskPhone(user.phoneNumber)}`}
+        />
+        <button
+          type="submit"
+          className="admin-btn admin-btn--sm"
+          disabled={pending}
+        >
+          {pending ? '…' : 'Save'}
+        </button>
+        {state?.error && (
+          <span className="admin-inline-error">{state.error}</span>
+        )}
+        {state?.success && (
+          <span className="admin-inline-success">{state.success}</span>
+        )}
+      </form>
+    </td>
+  );
 }
 
 export function StaffPhoneForm({ staffPhoneUsers }: Props) {
@@ -58,6 +97,16 @@ export function StaffPhoneForm({ staffPhoneUsers }: Props) {
               required
             />
           </div>
+          <label htmlFor="displayName" className="admin-label">
+            Name <span className="admin-label-optional">(optional)</span>
+          </label>
+          <input
+            id="displayName"
+            name="displayName"
+            type="text"
+            placeholder="e.g. Jamie"
+            className="admin-input"
+          />
           <button
             type="submit"
             className="admin-btn"
@@ -78,6 +127,7 @@ export function StaffPhoneForm({ staffPhoneUsers }: Props) {
         <thead>
           <tr>
             <th>Phone (masked)</th>
+            <th>Name</th>
             <th>UID</th>
             <th>Action</th>
           </tr>
@@ -86,6 +136,7 @@ export function StaffPhoneForm({ staffPhoneUsers }: Props) {
           {staffPhoneUsers.map(user => (
             <tr key={user.uid}>
               <td>{maskPhone(user.phoneNumber)}</td>
+              <DisplayNameCell user={user} />
               <td>{user.uid}</td>
               <td>
                 <form action={revokeAction}>
@@ -103,7 +154,7 @@ export function StaffPhoneForm({ staffPhoneUsers }: Props) {
           ))}
           {staffPhoneUsers.length === 0 && (
             <tr>
-              <td colSpan={3} className="admin-empty">
+              <td colSpan={4} className="admin-empty">
                 No staff phone users provisioned.
               </td>
             </tr>

--- a/src/app/(admin)/admin/users/StaffPhoneForm.tsx
+++ b/src/app/(admin)/admin/users/StaffPhoneForm.tsx
@@ -35,24 +35,29 @@ export function StaffPhoneForm({ staffPhoneUsers }: Props) {
     <div className="admin-table-wrap">
       <h2 className="admin-section-title">Staff Phone Access</h2>
       <p className="admin-section-desc">
-        Provision a staff role by phone number (E.164 format, e.g.{' '}
-        <code>+16155550123</code>). The user signs in via SMS OTP and receives
-        the <strong>staff</strong> role.
+        Provision a staff role by US phone number. The user signs in via SMS OTP
+        and receives the <strong>staff</strong> role.
       </p>
 
       <form action={provisionAction} className="admin-form">
         <div className="admin-form-row">
           <label htmlFor="phoneNumber" className="admin-label">
-            Phone Number (E.164)
+            Phone Number
           </label>
-          <input
-            id="phoneNumber"
-            name="phoneNumber"
-            type="tel"
-            placeholder="+16155550123"
-            className="admin-input"
-            required
-          />
+          <div className="admin-input-prefix-wrap">
+            <span className="admin-input-prefix">+1</span>
+            <input
+              id="phoneNumber"
+              name="phoneNumber"
+              type="tel"
+              placeholder="6155550123"
+              className="admin-input"
+              inputMode="numeric"
+              maxLength={10}
+              pattern="\d{10}"
+              required
+            />
+          </div>
           <button
             type="submit"
             className="admin-btn"

--- a/src/app/(admin)/admin/users/StaffPhoneForm.tsx
+++ b/src/app/(admin)/admin/users/StaffPhoneForm.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useActionState } from 'react';
+import { provisionStaffPhone, revokeStaffPhone } from './actions';
+
+interface StaffPhoneUser {
+  uid: string;
+  phoneNumber: string;
+}
+
+interface Props {
+  staffPhoneUsers: StaffPhoneUser[];
+}
+
+function maskPhone(phone: string): string {
+  // E.164 format: +1XXXXXXXXXX → +1 (XXX) ***-**XX (show last 2 digits)
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length < 10) return phone;
+  const last2 = digits.slice(-2);
+  const areaCode = digits.slice(-10, -7);
+  return `+1 (${areaCode}) ***-**${last2}`;
+}
+
+export function StaffPhoneForm({ staffPhoneUsers }: Props) {
+  const [provisionState, provisionAction, provisionPending] = useActionState(
+    provisionStaffPhone,
+    null
+  );
+  const [revokeState, revokeAction, revokePending] = useActionState(
+    revokeStaffPhone,
+    null
+  );
+
+  return (
+    <div className="admin-table-wrap">
+      <h2 className="admin-section-title">Staff Phone Access</h2>
+      <p className="admin-section-desc">
+        Provision a staff role by phone number (E.164 format, e.g.{' '}
+        <code>+16155550123</code>). The user signs in via SMS OTP and receives
+        the <strong>staff</strong> role.
+      </p>
+
+      <form action={provisionAction} className="admin-form">
+        <div className="admin-form-row">
+          <label htmlFor="phoneNumber" className="admin-label">
+            Phone Number (E.164)
+          </label>
+          <input
+            id="phoneNumber"
+            name="phoneNumber"
+            type="tel"
+            placeholder="+16155550123"
+            className="admin-input"
+            required
+          />
+          <button
+            type="submit"
+            className="admin-btn"
+            disabled={provisionPending}
+          >
+            {provisionPending ? 'Provisioning…' : 'Provision Staff'}
+          </button>
+        </div>
+        {provisionState?.error && (
+          <p className="admin-error">{provisionState.error}</p>
+        )}
+        {provisionState?.success && (
+          <p className="admin-success">{provisionState.success}</p>
+        )}
+      </form>
+
+      <table className="admin-table">
+        <thead>
+          <tr>
+            <th>Phone (masked)</th>
+            <th>UID</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {staffPhoneUsers.map(user => (
+            <tr key={user.uid}>
+              <td>{maskPhone(user.phoneNumber)}</td>
+              <td>{user.uid}</td>
+              <td>
+                <form action={revokeAction}>
+                  <input type="hidden" name="uid" value={user.uid} />
+                  <button
+                    type="submit"
+                    className="admin-btn admin-btn--danger"
+                    disabled={revokePending}
+                  >
+                    Revoke
+                  </button>
+                </form>
+              </td>
+            </tr>
+          ))}
+          {staffPhoneUsers.length === 0 && (
+            <tr>
+              <td colSpan={3} className="admin-empty">
+                No staff phone users provisioned.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      {revokeState?.error && <p className="admin-error">{revokeState.error}</p>}
+      {revokeState?.success && (
+        <p className="admin-success">{revokeState.success}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/users/actions.ts
+++ b/src/app/(admin)/admin/users/actions.ts
@@ -99,8 +99,8 @@ export async function revokeInvite(
   return { success: `Invite revoked for ${email}.` };
 }
 
-// E.164: starts with +, followed by 7–15 digits
-const E164_PATTERN = /^\+[1-9]\d{6,14}$/;
+// Accepts 10-digit US numbers; +1 is prepended server-side
+const US_PHONE_PATTERN = /^\d{10}$/;
 
 export async function provisionStaffPhone(
   _prev: ActionState | null,
@@ -108,17 +108,19 @@ export async function provisionStaffPhone(
 ): Promise<ActionState> {
   await requireRole('owner');
 
-  const phoneNumber = formData.get('phoneNumber')?.toString().trim();
+  const raw = formData.get('phoneNumber')?.toString().trim() ?? '';
 
-  if (!phoneNumber) {
+  if (!raw) {
     return { error: 'Phone number is required.' };
   }
 
-  if (!E164_PATTERN.test(phoneNumber)) {
+  if (!US_PHONE_PATTERN.test(raw)) {
     return {
-      error: 'Phone number must be in E.164 format (e.g. +16155550123).',
+      error: 'Enter a valid 10-digit US phone number (e.g. 6155550123).',
     };
   }
+
+  const phoneNumber = `+1${raw}`;
 
   const { getAdminAuth } = await import('@/lib/firebase/admin');
   const auth = getAdminAuth();

--- a/src/app/(admin)/admin/users/actions.ts
+++ b/src/app/(admin)/admin/users/actions.ts
@@ -98,3 +98,91 @@ export async function revokeInvite(
   revalidatePath('/admin/users');
   return { success: `Invite revoked for ${email}.` };
 }
+
+// E.164: starts with +, followed by 7–15 digits
+const E164_PATTERN = /^\+[1-9]\d{6,14}$/;
+
+export async function provisionStaffPhone(
+  _prev: ActionState | null,
+  formData: FormData
+): Promise<ActionState> {
+  await requireRole('owner');
+
+  const phoneNumber = formData.get('phoneNumber')?.toString().trim();
+
+  if (!phoneNumber) {
+    return { error: 'Phone number is required.' };
+  }
+
+  if (!E164_PATTERN.test(phoneNumber)) {
+    return {
+      error: 'Phone number must be in E.164 format (e.g. +16155550123).',
+    };
+  }
+
+  const { getAdminAuth } = await import('@/lib/firebase/admin');
+  const auth = getAdminAuth();
+
+  let uid: string;
+
+  try {
+    const existing = await auth.getUserByPhoneNumber(phoneNumber);
+    uid = existing.uid;
+    // Idempotent: if already staff, nothing changes — still set claims to ensure correctness
+    await auth.setCustomUserClaims(uid, {
+      ...(existing.customClaims ?? {}),
+      role: 'staff',
+    });
+  } catch (err: unknown) {
+    // auth/user-not-found → create the user
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      (err as Record<string, unknown>).code === 'auth/user-not-found'
+    ) {
+      const created = await auth.createUser({ phoneNumber });
+      uid = created.uid;
+      await auth.setCustomUserClaims(uid, { role: 'staff' });
+    } else if (err instanceof Error) {
+      return { error: err.message };
+    } else {
+      return { error: 'Failed to provision staff user.' };
+    }
+  }
+
+  revalidatePath('/admin/users');
+  return { success: `Phone ${phoneNumber} provisioned with staff role.` };
+}
+
+export async function revokeStaffPhone(
+  _prev: ActionState | null,
+  formData: FormData
+): Promise<ActionState> {
+  await requireRole('owner');
+
+  const uid = formData.get('uid')?.toString().trim();
+
+  if (!uid) {
+    return { error: 'UID is required.' };
+  }
+
+  const { getAdminAuth } = await import('@/lib/firebase/admin');
+  const auth = getAdminAuth();
+
+  try {
+    const user = await auth.getUser(uid);
+    await auth.setCustomUserClaims(uid, {
+      ...(user.customClaims ?? {}),
+      role: 'customer',
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return { error: err.message };
+    }
+
+    return { error: 'Failed to revoke staff role.' };
+  }
+
+  revalidatePath('/admin/users');
+  return { success: 'Staff role revoked. User demoted to customer.' };
+}

--- a/src/app/(admin)/admin/users/actions.ts
+++ b/src/app/(admin)/admin/users/actions.ts
@@ -109,6 +109,8 @@ export async function provisionStaffPhone(
   await requireRole('owner');
 
   const raw = formData.get('phoneNumber')?.toString().trim() ?? '';
+  const displayName =
+    formData.get('displayName')?.toString().trim() || undefined;
 
   if (!raw) {
     return { error: 'Phone number is required.' };
@@ -135,6 +137,9 @@ export async function provisionStaffPhone(
       ...(existing.customClaims ?? {}),
       role: 'staff',
     });
+    if (displayName) {
+      await auth.updateUser(uid, { displayName });
+    }
   } catch (err: unknown) {
     // auth/user-not-found → create the user
     if (
@@ -142,7 +147,7 @@ export async function provisionStaffPhone(
       err !== null &&
       (err as Record<string, unknown>).code === 'auth/user-not-found'
     ) {
-      const created = await auth.createUser({ phoneNumber });
+      const created = await auth.createUser({ phoneNumber, displayName });
       uid = created.uid;
       await auth.setCustomUserClaims(uid, { role: 'staff' });
     } else if (err instanceof Error) {
@@ -154,6 +159,35 @@ export async function provisionStaffPhone(
 
   revalidatePath('/admin/users');
   return { success: `Phone ${phoneNumber} provisioned with staff role.` };
+}
+
+export async function setStaffDisplayName(
+  _prev: ActionState | null,
+  formData: FormData
+): Promise<ActionState> {
+  await requireRole('owner');
+
+  const uid = formData.get('uid')?.toString().trim();
+  const displayName = formData.get('displayName')?.toString().trim() ?? '';
+
+  if (!uid) {
+    return { error: 'UID is required.' };
+  }
+
+  const { getAdminAuth } = await import('@/lib/firebase/admin');
+  const auth = getAdminAuth();
+
+  try {
+    await auth.updateUser(uid, { displayName: displayName || null });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return { error: err.message };
+    }
+    return { error: 'Failed to update display name.' };
+  }
+
+  revalidatePath('/admin/users');
+  return { success: 'Name updated.' };
 }
 
 export async function revokeStaffPhone(

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -3,13 +3,40 @@ export const dynamic = 'force-dynamic';
 import { requireRole } from '@/lib/admin-auth';
 import { listManagedUsers } from '@/lib/admin/user-management';
 import { listPendingUserInvites } from '@/lib/repositories';
+import { getAdminAuth } from '@/lib/firebase/admin';
 import { UserRoleForm } from './UserRoleForm';
+import { StaffPhoneForm } from './StaffPhoneForm';
+
+async function listStaffPhoneUsers() {
+  const auth = getAdminAuth();
+  const results: { uid: string; phoneNumber: string }[] = [];
+  let pageToken: string | undefined;
+
+  while (true) {
+    const page = await auth.listUsers(1000, pageToken);
+    for (const user of page.users) {
+      const claims = user.customClaims as Record<string, unknown> | undefined;
+      if (
+        user.phoneNumber &&
+        !user.email && // phone-only users
+        claims?.role === 'staff'
+      ) {
+        results.push({ uid: user.uid, phoneNumber: user.phoneNumber });
+      }
+    }
+    if (!page.pageToken) break;
+    pageToken = page.pageToken;
+  }
+
+  return results;
+}
 
 export default async function AdminUsersPage() {
   await requireRole('owner');
-  const [users, pendingInvites] = await Promise.all([
+  const [users, pendingInvites, staffPhoneUsers] = await Promise.all([
     listManagedUsers(),
     listPendingUserInvites(),
+    listStaffPhoneUsers(),
   ]);
 
   return (
@@ -23,6 +50,8 @@ export default async function AdminUsersPage() {
       </p>
 
       <UserRoleForm />
+
+      <StaffPhoneForm staffPhoneUsers={staffPhoneUsers} />
 
       <div className="admin-table-wrap">
         <h2 className="admin-section-title">Pending Invites</h2>

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -9,7 +9,8 @@ import { StaffPhoneForm } from './StaffPhoneForm';
 
 async function listStaffPhoneUsers() {
   const auth = getAdminAuth();
-  const results: { uid: string; phoneNumber: string }[] = [];
+  const results: { uid: string; phoneNumber: string; displayName: string }[] =
+    [];
   let pageToken: string | undefined;
 
   while (true) {
@@ -21,7 +22,11 @@ async function listStaffPhoneUsers() {
         !user.email && // phone-only users
         claims?.role === 'staff'
       ) {
-        results.push({ uid: user.uid, phoneNumber: user.phoneNumber });
+        results.push({
+          uid: user.uid,
+          phoneNumber: user.phoneNumber,
+          displayName: user.displayName ?? '',
+        });
       }
     }
     if (!page.pageToken) break;

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,19 +1,22 @@
 import Link from 'next/link';
 import { AdminNav } from './AdminNav';
+import { getAdminRole } from '@/lib/admin-auth';
 import '@/styles/admin.css';
 
-export default function AdminLayout({
+export default async function AdminLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const role = await getAdminRole();
+
   return (
     <div className="admin-root">
       <header className="admin-header">
         <Link href="/admin/dashboard" className="admin-brand">
           Rush N Relax Admin
         </Link>
-        <AdminNav />
+        <AdminNav role={role} />
       </header>
       <main className="admin-main">{children}</main>
     </div>

--- a/src/app/api/auth/session/route.test.ts
+++ b/src/app/api/auth/session/route.test.ts
@@ -67,6 +67,74 @@ describe('auth session route', () => {
     );
   });
 
+  it('creates a session for staff role', async () => {
+    // Given a valid ID token with role: 'staff'
+    verifyIdTokenMock.mockResolvedValue({
+      uid: 'staff-uid',
+      email: 'staff@rushnrelax.com',
+      role: 'staff',
+    });
+    createSessionCookieMock.mockResolvedValue('staff-session-cookie');
+
+    // When the session endpoint is called
+    const response = await POST(createPostRequest('staff-token'));
+
+    // Then a session cookie is set (200)
+    expect(response.status).toBe(200);
+    expect(createSessionCookieMock).toHaveBeenCalledWith('staff-token', {
+      expiresIn: 432000000,
+    });
+    expect(response.headers.get('Set-Cookie')).toContain(
+      '__session=staff-session-cookie'
+    );
+  });
+
+  it('creates a session for staff role with phone auth (no email)', async () => {
+    // Given a phone-auth staff user — no email field
+    verifyIdTokenMock.mockResolvedValue({
+      uid: 'phone-staff-uid',
+      phone_number: '+12345678900',
+      role: 'staff',
+    });
+    createSessionCookieMock.mockResolvedValue('phone-staff-cookie');
+
+    const response = await POST(createPostRequest('phone-staff-token'));
+
+    expect(response.status).toBe(200);
+    expect(createSessionCookieMock).toHaveBeenCalled();
+  });
+
+  it('returns 403 for customer role', async () => {
+    // Given a valid ID token with role: 'customer'
+    verifyIdTokenMock.mockResolvedValue({
+      uid: 'customer-uid',
+      email: 'customer@example.com',
+      role: 'customer',
+    });
+
+    // When the session endpoint is called
+    const response = await POST(createPostRequest('customer-token'));
+
+    // Then 403 is returned
+    expect(response.status).toBe(403);
+    expect(createSessionCookieMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when no role claim is present', async () => {
+    // Given a valid ID token with no role claim
+    verifyIdTokenMock.mockResolvedValue({
+      uid: 'no-role-uid',
+      email: 'unknown@example.com',
+    });
+
+    // When the session endpoint is called
+    const response = await POST(createPostRequest('no-role-token'));
+
+    // Then 403 is returned
+    expect(response.status).toBe(403);
+    expect(createSessionCookieMock).not.toHaveBeenCalled();
+  });
+
   it('bootstraps owner claim for allowlisted user and asks client to retry', async () => {
     process.env.ADMIN_OWNER_ALLOWLIST = 'owner@rushnrelax.com';
     verifyIdTokenMock.mockResolvedValue({
@@ -88,6 +156,7 @@ describe('auth session route', () => {
   });
 
   it('applies pending invite role and asks client to retry token', async () => {
+    // Given the email invite flow (pending invite exists)
     verifyIdTokenMock.mockResolvedValue({
       uid: 'invitee-uid',
       email: 'new.staff@rushnrelax.com',
@@ -100,9 +169,11 @@ describe('auth session route', () => {
     });
     getUserMock.mockResolvedValue({ customClaims: { betaFlag: true } });
 
+    // When the session endpoint is called
     const response = await POST(createPostRequest('invite-token'));
     const body = (await response.json()) as { code?: string };
 
+    // Then 409 CLAIMS_UPDATED_RETRY fires
     expect(response.status).toBe(409);
     expect(body.code).toBe('CLAIMS_UPDATED_RETRY');
     expect(setCustomUserClaimsMock).toHaveBeenCalledWith('invitee-uid', {
@@ -114,20 +185,6 @@ describe('auth session route', () => {
       acceptedByUid: 'invitee-uid',
     });
     expect(createSessionCookieMock).not.toHaveBeenCalled();
-  });
-
-  it('returns forbidden when user is not owner and not allowlisted', async () => {
-    verifyIdTokenMock.mockResolvedValue({
-      uid: 'staff-uid',
-      email: 'staff@rushnrelax.com',
-      role: 'staff',
-    });
-
-    const response = await POST(createPostRequest('staff-token'));
-
-    expect(response.status).toBe(403);
-    expect(createSessionCookieMock).not.toHaveBeenCalled();
-    expect(setCustomUserClaimsMock).not.toHaveBeenCalled();
   });
 
   it('clears the session cookie on delete', () => {

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -4,11 +4,12 @@ import {
   markPendingUserInviteAccepted,
   normalizeInviteEmail,
 } from '@/lib/repositories';
+import type { UserRole } from '@/types';
 
 const SESSION_DURATION_MS = 60 * 60 * 24 * 5 * 1000; // 5 days
 const SESSION_MAX_AGE_S = 60 * 60 * 24 * 5; // 5 days in seconds
 
-const OWNER_ROLE = 'owner';
+const OWNER_ROLE: UserRole = 'owner';
 const CLAIMS_UPDATED_RETRY_CODE = 'CLAIMS_UPDATED_RETRY';
 
 function getRoleClaim(payload: unknown): unknown {
@@ -17,6 +18,20 @@ function getRoleClaim(payload: unknown): unknown {
   }
 
   return (payload as Record<string, unknown>).role;
+}
+
+function isUserRole(value: unknown): value is UserRole {
+  return (
+    value === 'customer' ||
+    value === 'staff' ||
+    value === 'storeOwner' ||
+    value === 'storeManager' ||
+    value === 'owner'
+  );
+}
+
+function isStaffOrAbove(role: UserRole): boolean {
+  return role !== 'customer';
 }
 
 function parseOwnerAllowlist(): Set<string> {
@@ -32,6 +47,9 @@ function parseOwnerAllowlist(): Set<string> {
  * POST /api/auth/session
  * Exchange a Firebase ID token for a server-side session cookie.
  * Body: { idToken: string }
+ *
+ * Session cookie is issued only when the user holds a recognized, non-customer role.
+ * Gate: isUserRole(roleClaim) && roleClaim !== 'customer'
  */
 export async function POST(request: Request): Promise<Response> {
   let idToken: string;
@@ -61,7 +79,29 @@ export async function POST(request: Request): Promise<Response> {
       ? normalizeInviteEmail(decoded.email)
       : undefined;
 
-    if (roleClaim !== OWNER_ROLE) {
+    // Owner allowlist bootstrap: elevate the user to owner then ask client to retry.
+    if (roleClaim !== OWNER_ROLE && normalizedEmail) {
+      const isAllowlisted = parseOwnerAllowlist().has(normalizedEmail);
+
+      if (isAllowlisted) {
+        const userRecord = await adminAuth.getUser(decoded.uid);
+        await adminAuth.setCustomUserClaims(decoded.uid, {
+          ...(userRecord.customClaims ?? {}),
+          role: OWNER_ROLE,
+        });
+
+        return Response.json(
+          {
+            error: 'Owner claim applied. Refreshing token required.',
+            code: CLAIMS_UPDATED_RETRY_CODE,
+          },
+          { status: 409 }
+        );
+      }
+    }
+
+    // Email invite flow: apply the pending role then ask client to retry.
+    if (!isUserRole(roleClaim) || !isStaffOrAbove(roleClaim)) {
       if (normalizedEmail) {
         const pendingInvite =
           await getPendingUserInviteByEmail(normalizedEmail);
@@ -92,26 +132,7 @@ export async function POST(request: Request): Promise<Response> {
         }
       }
 
-      const isAllowlisted = Boolean(
-        normalizedEmail && parseOwnerAllowlist().has(normalizedEmail)
-      );
-
-      if (isAllowlisted) {
-        const userRecord = await adminAuth.getUser(decoded.uid);
-        await adminAuth.setCustomUserClaims(decoded.uid, {
-          ...(userRecord.customClaims ?? {}),
-          role: OWNER_ROLE,
-        });
-
-        return Response.json(
-          {
-            error: 'Owner claim applied. Refreshing token required.',
-            code: CLAIMS_UPDATED_RETRY_CODE,
-          },
-          { status: 409 }
-        );
-      }
-
+      // No valid staff-or-above role and no pending invite — reject.
       return Response.json({ error: 'Forbidden' }, { status: 403 });
     }
 

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -46,6 +46,7 @@ export interface AdminActorContext {
   uid: string;
   email: string;
   role: UserRole;
+  phone?: string;
 }
 
 async function resolveActorFromSessionCookie(
@@ -73,6 +74,7 @@ async function resolveActorFromSessionCookie(
     uid: decoded.uid,
     email: decoded.email ?? '',
     role,
+    phone: decoded.phone_number ?? undefined,
   };
 }
 
@@ -107,4 +109,31 @@ export async function requireRole(
   }
 
   return actor;
+}
+
+/**
+ * Decode the role from the session cookie without full verification.
+ * Used in server-rendered layouts where we only need the role for UI filtering.
+ * Full verification still happens in requireRole() in every Server Action.
+ */
+export async function getAdminRole(): Promise<UserRole | null> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('__session')?.value;
+  if (!sessionCookie) return null;
+
+  // Session cookies are structured as JWTs: header.payload.signature
+  // We only base64-decode the payload — no signature verification here.
+  // requireRole() in every Server Action performs full cryptographic verification.
+  try {
+    const parts = sessionCookie.split('.');
+    if (parts.length < 2) return null;
+    // base64url → standard base64
+    const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(padded);
+    const payload: unknown = JSON.parse(json);
+    const role = getRoleClaim(payload);
+    return isUserRole(role) ? role : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,0 +1,24 @@
+/**
+ * Lightweight JWT payload decoder for Edge Runtime (middleware).
+ *
+ * Only base64-decodes the payload segment — NO signature verification.
+ * Full cryptographic verification happens in requireRole() via Firebase Admin SDK
+ * in every Server Action that needs it.
+ */
+
+/**
+ * Decode the payload of a JWT string.
+ * Returns the parsed JSON object on success, or null on any error (never throws).
+ */
+export function decodeJwtPayload(token: string): unknown {
+  try {
+    const parts = token.split('.');
+    if (parts.length < 2) return null;
+    // base64url → standard base64
+    const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const json = atob(padded);
+    return JSON.parse(json) as unknown;
+  } catch {
+    return null;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,6 +17,7 @@ export const config = {
 
 /** Routes staff users are permitted to access under /admin */
 const STAFF_PERMITTED_PREFIXES = [
+  '/admin/dashboard',
   '/admin/products',
   '/admin/categories',
   '/admin/coa',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { seoConfig } from '@/config/seo.config';
+import { decodeJwtPayload } from '@/lib/jwt';
 
 export const config = {
   matcher: [
@@ -13,6 +14,21 @@ export const config = {
     '/((?!_next/static|_next/image|favicon\\.ico|icons/|images/|og/|__firebaseapphosting/).*)',
   ],
 };
+
+/** Routes staff users are permitted to access under /admin */
+const STAFF_PERMITTED_PREFIXES = [
+  '/admin/products',
+  '/admin/categories',
+  '/admin/coa',
+  '/admin/login',
+] as const;
+
+function getSessionRole(sessionCookie: string): string | null {
+  const payload = decodeJwtPayload(sessionCookie);
+  if (typeof payload !== 'object' || payload === null) return null;
+  const role = (payload as Record<string, unknown>).role;
+  return typeof role === 'string' ? role : null;
+}
 
 export function middleware(request: NextRequest) {
   const url = request.nextUrl.clone();
@@ -29,6 +45,20 @@ export function middleware(request: NextRequest) {
     if (!sessionCookie) {
       url.pathname = '/admin/login';
       return NextResponse.redirect(url);
+    }
+
+    // Staff role guard — restrict staff to permitted routes only.
+    // No Firebase Admin SDK here (Edge Runtime). Payload decode only — no sig verify.
+    // Full verification still happens in requireRole() in every Server Action.
+    const role = getSessionRole(sessionCookie);
+    if (role === 'staff') {
+      const isPermitted = STAFF_PERMITTED_PREFIXES.some(prefix =>
+        pathname.startsWith(prefix)
+      );
+      if (!isPermitted) {
+        url.pathname = '/admin/products';
+        return NextResponse.redirect(url);
+      }
     }
   }
 

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1044,6 +1044,24 @@
   font-size: 0.8rem;
 }
 
+.admin-input--inline {
+  flex: 1 1 160px;
+  min-width: 0;
+  margin: 0;
+}
+
+.admin-btn--sm {
+  padding: var(--admin-actions-button-padding);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.admin-label-optional {
+  color: var(--admin-text-subtle);
+  font-size: 0.8rem;
+  font-weight: 400;
+}
+
 .admin-status-badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Closes #92, Closes #93, Closes #94, Closes #96, Closes #97, Closes #98, Closes #100, Closes #101, Closes #107

## Summary

This PR implements end-to-end staff/phone-auth access control for the admin panel:

- **#92 — AdminActorContext phone field**: Added `phone?: string` to `AdminActorContext` populated from `decoded.phone_number`. Also added `getAdminRole()` helper for server-rendered UI (note: this work was bundled with the pre-existing #95 commit on the branch which added staff provisioning).
- **#93 — Staff+ session cookies**: Rewrote `/api/auth/session` gate from `role === 'owner'` to `isUserRole(role) && role !== 'customer'`. Owner allowlist bootstrap and email invite flow (409 CLAIMS_UPDATED_RETRY) preserved exactly. Phone-auth staff users with no email are now accepted.
- **#96 — Middleware staff route guard**: Added `src/lib/jwt.ts` with `decodeJwtPayload()` (base64 decode only, no sig verify — Edge Runtime safe). Middleware decodes session cookie, checks role, and redirects `staff` away from non-permitted routes to `/admin/products`.
- **#97 — Products/categories requireRole relaxed**: All six product and category server actions changed from `requireRole('owner')` to `requireRole('staff')`. Owner still works via role hierarchy.
- **#107 — COA requireRole relaxed**: `deleteCoaDocument` changed from `requireRole('owner')` to `requireRole('staff')`. All three COA actions now accept staff.
- **#98 — Role-aware AdminNav**: Layout calls `getAdminRole()` server-side and passes role to `AdminNav`. Staff sees only Products, Categories, COA, Client Site, logout. Owner sees full nav. Pinned links (Inventory, Users) hidden for staff.
- **#94 — Phone OTP login UI**: Added Google/Phone tab toggle to login page. Phone tab uses `signInWithPhoneNumber` + invisible reCAPTCHA + OTP confirm step. 403 from session endpoint shows "not authorized" message (no redirect loop). RecaptchaVerifier cleaned up on unmount.
- **#100 — Session route tests**: Extended `route.test.ts` with 5 new scenarios: staff 200, phone-auth staff 200, customer 403, no-role 403, invite flow 409 regression. 8 tests total passing.
- **#101 — Middleware + JWT tests**: New `src/__tests__/lib/jwt.test.ts` (5 tests) and `src/__tests__/middleware.test.ts` (5 tests). All 10 passing.

## Note on branch history

This branch (`worker/feature-staff-phone-login`) already contained a commit for #95 (staff provisioning) from a prior session. The `admin-auth.ts` changes for #92 were part of that commit. The PR closes #92 via this description.

---
Generated by BrewCortex worker agent