### PR TITLE
refactor: streamline admin UI and surface admin bar for all staff roles

### DIFF
--- a/src/app/(admin)/AdminNav.tsx
+++ b/src/app/(admin)/AdminNav.tsx
@@ -10,22 +10,16 @@ import type { UserRole } from '@/types';
 
 const LEAF_SRC = getAssetSrc(cannabisLeaf);
 
-const PINNED = [
-  { label: 'Inventory', href: '/admin/inventory' },
-  { label: 'Users', href: '/admin/users' },
-] as const;
+const PINNED = [{ label: 'RnR.com', href: '/' }] as const;
 
 const ALL_LINKS = [
   { label: 'Dashboard', href: '/admin/dashboard' },
   { label: 'Locations', href: '/admin/locations' },
   { label: 'Products', href: '/admin/products' },
   { label: 'Categories', href: '/admin/categories' },
-  { label: 'Promos', href: '/admin/promos' },
   { label: 'Inventory', href: '/admin/inventory' },
   { label: 'Users', href: '/admin/users' },
-  { label: 'Email Templates', href: '/admin/email-templates' },
-  { label: 'Email Queue', href: '/admin/email-queue' },
-  { label: '← Client Site', href: '/' },
+  { label: 'RnR.com', href: '/' },
 ] as const;
 
 /** Links available to staff role (and above via the full ALL_LINKS list). */
@@ -33,7 +27,7 @@ const STAFF_LINKS = [
   { label: 'Products', href: '/admin/products' },
   { label: 'Categories', href: '/admin/categories' },
   { label: 'COA', href: '/admin/coa' },
-  { label: '← Client Site', href: '/' },
+  { label: 'RnR.com', href: '/' },
 ] as const;
 
 interface AdminNavProps {

--- a/src/app/(admin)/admin/dashboard/DashboardGrid.tsx
+++ b/src/app/(admin)/admin/dashboard/DashboardGrid.tsx
@@ -33,19 +33,8 @@ const ALL_CARDS: DashboardCard[] = [
   { id: 'locations', label: 'Manage Locations', href: '/admin/locations' },
   { id: 'products', label: 'Manage Products', href: '/admin/products' },
   { id: 'categories', label: 'Manage Categories', href: '/admin/categories' },
-  { id: 'promos', label: 'Manage Promos', href: '/admin/promos' },
   { id: 'inventory', label: 'Manage Inventory', href: '/admin/inventory' },
   { id: 'users', label: 'Manage Users', href: '/admin/users' },
-  {
-    id: 'email-templates',
-    label: 'Manage Email Templates',
-    href: '/admin/email-templates',
-  },
-  {
-    id: 'email-queue',
-    label: 'Monitor Email Queue',
-    href: '/admin/email-queue',
-  },
   { id: 'coa', label: 'Certificates of Analysis', href: '/admin/coa' },
 ];
 

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -4,7 +4,6 @@ import { requireRole } from '@/lib/admin-auth';
 import { listManagedUsers } from '@/lib/admin/user-management';
 import { listPendingUserInvites } from '@/lib/repositories';
 import { getAdminAuth } from '@/lib/firebase/admin';
-import { UserRoleForm } from './UserRoleForm';
 import { StaffPhoneForm } from './StaffPhoneForm';
 
 async function listStaffPhoneUsers() {
@@ -49,13 +48,6 @@ export default async function AdminUsersPage() {
       <div className="admin-page-header">
         <h1>Users</h1>
       </div>
-      <p className="admin-section-desc">
-        Invite users by email and assign a role, or assign roles to existing
-        Firebase Auth users. Owner accounts remain immutable from this panel.
-      </p>
-
-      <UserRoleForm />
-
       <StaffPhoneForm staffPhoneUsers={staffPhoneUsers} />
 
       <div className="admin-table-wrap">

--- a/src/app/(storefront)/layout.tsx
+++ b/src/app/(storefront)/layout.tsx
@@ -11,7 +11,7 @@ export default async function StorefrontLayout({
 }) {
   const cookieStore = await cookies();
   const initiallyVerified = cookieStore.get('ageVerified')?.value === 'true';
-  const isAdminAuthenticated = await hasAdminSession();
+  const isAdminAuthenticated = await hasAdminSession('staff');
 
   return (
     <NavigationProvider>

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1025,13 +1025,14 @@
 
 .admin-inline-form {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: var(--admin-inline-form-gap);
-  width: 100%;
+  width: auto;
+  align-items: center;
 }
 
 .admin-inline-form input {
-  flex: 1 1 220px;
+  flex: 0 1 140px;
   margin: 0;
 }
 
@@ -1045,8 +1046,9 @@
 }
 
 .admin-input--inline {
-  flex: 1 1 160px;
-  min-width: 0;
+  flex: 0 1 140px;
+  min-width: 80px;
+  max-width: 160px;
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary

- **Admin nav**: replaced Inventory + Users pinned links with a single `RnR.com` shortcut back to the client site; removed Promos, Email Templates, Email Queue from the drawer
- **Dashboard**: pruned Promos, Manage Email Templates, Monitor Email Queue cards — dashboard is now focused on what matters
- **Users page**: dropped the Invite User and Assign Existing User Role panels (confusing for now); page opens directly on Staff Phone Access
- **Name cell**: constrained the inline edit input so the Name column renders compact and clean instead of stretching the row
- **Storefront admin bar**: lowered `hasAdminSession` threshold from `owner` → `staff` so all authenticated roles (staff, storeManager, owner) see the Admin + Logout buttons in the client-site header

## Test plan

- [ ] Log in as owner — confirm `RnR.com` appears in admin header, drawer links are correct, dashboard shows 6 cards
- [ ] Log in as staff — confirm storefront header shows ADMIN + LOGOUT pills
- [ ] Users page shows Staff Phone Access directly, no invite/assign panels
- [ ] Name cell in the staff phone table is short and inline, not full-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)