### PR TITLE
fix: product page storefront polish

### DIFF
--- a/src/app/(storefront)/products/[slug]/ProductDetailClient.tsx
+++ b/src/app/(storefront)/products/[slug]/ProductDetailClient.tsx
@@ -194,11 +194,19 @@ export default function ProductDetailClient({
                     aria-pressed={selectedVariant === v.key}
                   >
                     <span className="product-variant-card-size">{v.label}</span>
-                    <span className="product-variant-card-price">—</span>
+                    <span className="product-variant-card-price">See in store</span>
                   </button>
                 ))}
               </div>
             </div>
+
+            {/* Primary CTA — above the fold */}
+            <Link
+              href="/locations"
+              className="btn btn-primary"
+            >
+              Find a Location Near You
+            </Link>
 
             {/* Info table — Terpenes + cannabinoid detail */}
             {(terpenes.length > 0 || hasLabData) && (
@@ -248,6 +256,7 @@ export default function ProductDetailClient({
       {product.details && (
         <section className="product-details-section asymmetry-section-stable">
           <div className="container">
+            <h2 className="product-section-heading">Description</h2>
             <p className="product-details-body">{product.details}</p>
           </div>
         </section>
@@ -257,6 +266,7 @@ export default function ProductDetailClient({
       {coaSignedUrl && (
         <section className="product-coa-section asymmetry-section-stable">
           <div className="container">
+            <p className="product-coa-context">Third-party lab tested — view the full certificate of analysis</p>
             <a
               href={coaSignedUrl}
               target="_blank"
@@ -317,7 +327,7 @@ export default function ProductDetailClient({
           </p>
           <Link
             href="/locations"
-            className="btn btn-primary asymmetry-motion-anchor"
+            className="btn btn-secondary asymmetry-motion-anchor"
           >
             Find a Location
           </Link>

--- a/src/styles/products.css
+++ b/src/styles/products.css
@@ -205,7 +205,7 @@
 
 .back-to-products {
   padding: var(--space-sm);
-  text-align: center;
+  text-align: left;
 }
 
 .back-to-products .link-button {
@@ -423,7 +423,7 @@
 }
 
 .product-hero-tag-label {
-  font-size: 0.6rem;
+  font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -521,7 +521,7 @@
 }
 
 .product-variant-card-price {
-  font-size: 0.65rem;
+  font-size: 0.75rem;
   font-weight: 500;
   color: var(--color-text-subtle);
   transition: color 0.18s ease;
@@ -793,4 +793,21 @@
   .related-strip-card {
     flex: 0 0 170px;
   }
+}
+
+/* ── Product detail copy helpers ────────────────────────────────────────── */
+
+.product-section-heading {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+  margin-bottom: var(--space-sm);
+}
+
+.product-coa-context {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-sm);
 }


### PR DESCRIPTION
Closes #117

## What
Quick UX polish pass on the product detail page storefront:

- **Back link**: `text-align: center` → `left` so it sits flush with the page edge
- **Tag label font-size**: `.product-hero-tag-label` bumped from `0.6rem` → `0.7rem` for legibility
- **Variant card price font-size**: `.product-variant-card-price` bumped from `0.65rem` → `0.75rem`
- **Variant card price copy**: hardcoded `—` replaced with `See in store`
- **Primary CTA placement**: added `Find a Location Near You` button directly in the hero info column after the pricing block (above the fold); the bottom CTA section is now styled as `btn-secondary`
- **Description heading**: added `<h2 className="product-section-heading">Description</h2>` above the details paragraph
- **COA context copy**: added `product-coa-context` paragraph above the Certificate of Analysis button
- **New CSS utilities**: added `.product-section-heading` and `.product-coa-context` rules to `products.css`

## Agent
Worked by: worker agent (inline)

---
Generated by BrewCortex worker agent