### PR TITLE
perf: server-side hero image URL — fix LCP

### DIFF
--- a/src/app/(storefront)/products/[slug]/ProductDetailClient.tsx
+++ b/src/app/(storefront)/products/[slug]/ProductDetailClient.tsx
@@ -44,10 +44,18 @@ export default function ProductDetailClient({
   product,
   relatedProducts,
   coaSignedUrl,
+  heroImageUrl,
 }: {
   product: Product;
   relatedProducts: ProductSummary[];
   coaSignedUrl?: string;
+  /**
+   * Server-resolved public Firebase Storage URL for the hero image.
+   * When provided, the hero <img> is rendered directly (no client-side
+   * getDownloadURL call) so the browser can see the src at SSR time and
+   * preload it — fixing the LCP regression.
+   */
+  heroImageUrl?: string;
 }) {
   const variants = getVariantsForCategory(product.category);
   const sizeLabel = getSizeLabelForCategory(product.category);
@@ -89,6 +97,11 @@ export default function ProductDetailClient({
   const showEffectsGroup =
     product.labResults?.thcPercent !== undefined || effects.length > 0;
 
+  // When the user clicks a thumbnail, we may need to show the server-resolved
+  // hero URL (for the primary image) or fall back to ProductImage (for gallery
+  // images whose URLs were not pre-resolved).
+  const isActiveImagePrimary = activeImage === product.image;
+
   return (
     <main className="product-detail-page">
       <section className="back-to-products">
@@ -125,12 +138,29 @@ export default function ProductDetailClient({
               </div>
             )}
             <div className="product-main-image-wrap">
-              <ProductImage
-                slug={product.slug}
-                path={activeImage ?? product.image}
-                alt={product.name}
-                className="product-main-img"
-              />
+              {/* Render the hero image directly when the server-resolved URL is
+                  available and the primary image is active — this lets the browser
+                  see the src at SSR time and start loading immediately (LCP fix).
+                  For gallery images (non-primary), fall back to ProductImage. */}
+              {heroImageUrl && isActiveImagePrimary ? (
+                <div className="product-card-img product-main-img">
+                  <img
+                    src={heroImageUrl}
+                    alt={product.name}
+                    className="product-image product-image-loaded"
+                    fetchPriority="high"
+                    loading="eager"
+                    decoding="async"
+                  />
+                </div>
+              ) : (
+                <ProductImage
+                  slug={product.slug}
+                  path={activeImage ?? product.image}
+                  alt={product.name}
+                  className="product-main-img"
+                />
+              )}
             </div>
           </div>
 

--- a/src/app/(storefront)/products/[slug]/page.tsx
+++ b/src/app/(storefront)/products/[slug]/page.tsx
@@ -15,6 +15,18 @@ interface Props {
 
 export const revalidate = 3600;
 
+const STORAGE_BUCKET = 'rush-n-relax.firebasestorage.app';
+
+/**
+ * Build a public (no-auth) Firebase Storage download URL from a storage path.
+ * This avoids a client-side getDownloadURL round-trip for the hero image,
+ * which was causing a 1–3s LCP penalty.
+ */
+function buildPublicStorageUrl(storagePath: string): string {
+  const encodedPath = encodeURIComponent(storagePath);
+  return `https://firebasestorage.googleapis.com/v0/b/${STORAGE_BUCKET}/o/${encodedPath}?alt=media`;
+}
+
 export async function generateMetadata({ params }: Props) {
   const { slug } = await params;
   const product = await getProductBySlug(slug);
@@ -39,6 +51,12 @@ export default async function ProductDetailPage({ params }: Props) {
   const relatedProducts = activeProducts
     .filter(candidate => candidate.slug !== product.slug)
     .slice(0, 6);
+
+  // Resolve hero image URL server-side to avoid client-side Firebase Storage
+  // getDownloadURL round-trip, which blocks LCP by 1–3s.
+  const heroImageUrl = product.image
+    ? buildPublicStorageUrl(product.image)
+    : undefined;
 
   // Generate a fresh signed URL for the COA PDF if one is stored.
   // Page revalidates every hour so the 1-hour signed URL stays valid.
@@ -79,6 +97,7 @@ export default async function ProductDetailPage({ params }: Props) {
         product={product}
         relatedProducts={relatedProducts}
         coaSignedUrl={coaSignedUrl}
+        heroImageUrl={heroImageUrl}
       />
     </>
   );


### PR DESCRIPTION
Closes #120

## What
- `page.tsx`: added `buildPublicStorageUrl()` helper that constructs a public Firebase Storage URL from a storage path using the pattern `https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{encodedPath}?alt=media`. The `product.image` storage path is resolved at server render time and passed as `heroImageUrl` prop to `ProductDetailClient`.
- `ProductDetailClient.tsx`: accepts the new `heroImageUrl?: string` prop. When present and the primary image is active, renders `<img src={heroImageUrl} fetchPriority="high" loading="eager">` directly — bypassing the `ProductImage` component's client-side `getDownloadURL` chain entirely. Gallery images and thumbnails continue to use `ProductImage` as before.
- `ProductImage/index.tsx`: unchanged.

## Why
The previous flow — `useEffect` → `getDownloadURL` → `setSrc` — meant the browser had no image `src` at SSR time and couldn't preload the hero image, causing a 1–3s LCP penalty. The new approach embeds the URL in the SSR response so the browser starts fetching immediately.

## Agent
Worked by: worker agent (inline)

---
Generated by BrewCortex worker agent