### PR TITLE
fix: admin UI polish — field-level validation, toggle feedback, inventory hint

### DIFF
--- a/src/app/(admin)/admin/inventory/[locationId]/InventoryTable.tsx
+++ b/src/app/(admin)/admin/inventory/[locationId]/InventoryTable.tsx
@@ -76,6 +76,7 @@ function InventoryRow({
   const [availablePickup, setAvailablePickup] = useState(row.availablePickup);
   const [featured, setFeatured] = useState(row.featured);
   const [updateError, setUpdateError] = useState<string | null>(null);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const quantity = normalizeQuantityInput(quantityInput);
   const inStock = quantity > 0;
@@ -83,12 +84,22 @@ function InventoryRow({
   // Hub: featured requires availableOnline; retail: featured requires inStock
   const featuredEnabled = isHub ? availableOnline : inStock;
 
+  function triggerSuccess() {
+    setShowSuccess(true);
+    setTimeout(() => setShowSuccess(false), 1500);
+  }
+
   function handleToggle(
     field: 'inStock' | 'availableOnline' | 'availablePickup' | 'featured',
     value: boolean
   ) {
     setUpdateError(null);
-    const previous = { quantityInput, availableOnline, availablePickup, featured };
+    const previous = {
+      quantityInput,
+      availableOnline,
+      availablePickup,
+      featured,
+    };
 
     if (field === 'inStock') {
       const nextQuantity = value ? Math.max(quantity, 1) : 0;
@@ -117,7 +128,13 @@ function InventoryRow({
       field === 'inStock'
         ? {
             quantity: value ? Math.max(quantity, 1) : 0,
-            ...(value ? {} : { availableOnline: false, availablePickup: false, featured: false }),
+            ...(value
+              ? {}
+              : {
+                  availableOnline: false,
+                  availablePickup: false,
+                  featured: false,
+                }),
           }
         : field === 'availableOnline'
           ? { availableOnline: value, ...(!value ? { featured: false } : {}) }
@@ -129,6 +146,7 @@ function InventoryRow({
       try {
         await updateInventoryItem(locationId, row.id, nextPatch);
         setUpdateError(null);
+        triggerSuccess();
         router.refresh();
       } catch {
         setQuantityInput(previous.quantityInput);
@@ -176,6 +194,7 @@ function InventoryRow({
           ...(nextFeatured !== featured ? { featured: nextFeatured } : {}),
         });
         setUpdateError(null);
+        triggerSuccess();
         router.refresh();
       } catch {
         setQuantityInput(previous.quantityInput);
@@ -188,12 +207,7 @@ function InventoryRow({
 
   return (
     <tr className={isPending ? 'admin-row-pending' : undefined}>
-      <td>
-        {row.name}
-        {updateError && (
-          <span className="admin-inline-error">{updateError}</span>
-        )}
-      </td>
+      <td>{row.name}</td>
       <td>{row.category}</td>
       <td className="admin-qty-cell">
         <input
@@ -215,14 +229,29 @@ function InventoryRow({
         />
       </td>
       <td className="admin-col-toggle">
-        <input
-          type="checkbox"
-          className="admin-toggle"
-          checked={inStock}
-          disabled={isPending}
-          onChange={e => handleToggle('inStock', e.target.checked)}
-          aria-label={`In stock for ${row.name}`}
-        />
+        <span className="admin-toggle-cell">
+          <input
+            type="checkbox"
+            className="admin-toggle"
+            checked={inStock}
+            disabled={isPending}
+            onChange={e => handleToggle('inStock', e.target.checked)}
+            aria-label={`In stock for ${row.name}`}
+          />
+          {updateError && (
+            <span className="admin-inline-error">{updateError}</span>
+          )}
+          <span
+            className={
+              showSuccess
+                ? 'admin-toggle-success admin-toggle-success--visible'
+                : 'admin-toggle-success'
+            }
+            aria-hidden="true"
+          >
+            ✓
+          </span>
+        </span>
       </td>
       {isHub && (
         <td className="admin-col-toggle">

--- a/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
+++ b/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
@@ -124,10 +124,17 @@ export function ProductEditForm({ product, categories }: Props) {
             <input
               name="labResults_thcPercent"
               type="number"
-              min={0}
-              max={100}
-              step={0.01}
+              min="0"
+              max="100"
+              step="0.1"
               defaultValue={product.labResults?.thcPercent ?? ''}
+              aria-describedby="thcPercent-error"
+            />
+            <p
+              id="thcPercent-error"
+              className="admin-field-error"
+              aria-live="polite"
+              hidden
             />
           </label>
 
@@ -136,10 +143,17 @@ export function ProductEditForm({ product, categories }: Props) {
             <input
               name="labResults_cbdPercent"
               type="number"
-              min={0}
-              max={100}
-              step={0.01}
+              min="0"
+              max="100"
+              step="0.1"
               defaultValue={product.labResults?.cbdPercent ?? ''}
+              aria-describedby="cbdPercent-error"
+            />
+            <p
+              id="cbdPercent-error"
+              className="admin-field-error"
+              aria-live="polite"
+              hidden
             />
           </label>
 
@@ -171,6 +185,12 @@ export function ProductEditForm({ product, categories }: Props) {
           </label>
         </fieldset>
       </fieldset>
+
+      <p className="admin-hint">
+        Location availability is managed per-location. Go to{' '}
+        <Link href="/admin/inventory">Inventory</Link> to set which locations
+        carry this product.
+      </p>
 
       <div className="admin-form-actions">
         <Link href="/admin/products">Cancel</Link>

--- a/src/app/(admin)/admin/products/new/ProductCreateForm.tsx
+++ b/src/app/(admin)/admin/products/new/ProductCreateForm.tsx
@@ -111,9 +111,16 @@ export function ProductCreateForm({ categories }: Props) {
             <input
               name="labResults_thcPercent"
               type="number"
-              min={0}
-              max={100}
-              step={0.01}
+              min="0"
+              max="100"
+              step="0.1"
+              aria-describedby="thcPercent-error"
+            />
+            <p
+              id="thcPercent-error"
+              className="admin-field-error"
+              aria-live="polite"
+              hidden
             />
           </label>
 
@@ -122,9 +129,16 @@ export function ProductCreateForm({ categories }: Props) {
             <input
               name="labResults_cbdPercent"
               type="number"
-              min={0}
-              max={100}
-              step={0.01}
+              min="0"
+              max="100"
+              step="0.1"
+              aria-describedby="cbdPercent-error"
+            />
+            <p
+              id="cbdPercent-error"
+              className="admin-field-error"
+              aria-live="polite"
+              hidden
             />
           </label>
 

--- a/src/app/(storefront)/products/[slug]/ProductDetailClient.tsx
+++ b/src/app/(storefront)/products/[slug]/ProductDetailClient.tsx
@@ -61,8 +61,10 @@ export default function ProductDetailClient({
   const sizeLabel = getSizeLabelForCategory(product.category);
 
   // Featured image is always first; gallery images follow in order.
+  // heroImageUrl is a pre-resolved public URL (server-side) for faster LCP.
+  const featuredUrl = heroImageUrl ?? product.image;
   const allImages: string[] = [
-    ...(product.image ? [product.image] : []),
+    ...(featuredUrl ? [featuredUrl] : []),
     ...(product.images ?? []),
   ];
   const [activeImage, setActiveImage] = useState<string | undefined>(

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -52,6 +52,7 @@
   --admin-tag-field-focus-outline: 2px solid;
   --admin-tag-field-focus-outline-color: rgba(213, 179, 106, 0.2);
   --admin-chip-gap: 0.3rem;
+  --admin-toggle-cell-gap: 0.25rem;
   --admin-chip-padding: 0.2rem 0.55rem;
   --admin-chip-bg: rgba(213, 179, 106, 0.15);
   --admin-chip-border: 1px solid rgba(213, 179, 106, 0.35);
@@ -815,6 +816,23 @@
 .admin-toggle:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+.admin-toggle-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--admin-toggle-cell-gap);
+}
+
+.admin-toggle-success {
+  color: var(--admin-accent);
+  font-size: 0.85rem;
+  opacity: 0;
+  transition: opacity 1.5s ease-out;
+}
+
+.admin-toggle-success--visible {
+  opacity: 1;
 }
 
 .admin-row-pending td {


### PR DESCRIPTION
Closes #119

## What
- **Field-level validation (ProductCreateForm + ProductEditForm):** THC% and CBD% numeric inputs now have `min="0"` `max="100"` `step="0.1"` HTML5 attributes, `aria-describedby` pointing to hidden error `<p>` elements ready for validation message surfacing.
- **Inventory toggle success feedback (InventoryTable):** After a successful toggle or quantity commit, a ✓ checkmark fades in next to the In Stock toggle over 1.5s using CSS class-toggled opacity transition. Error display moved to the same toggle cell (removed from product name cell).
- **Location availability hint (ProductEditForm):** Added an `admin-hint` paragraph above form actions linking to `/admin/inventory` explaining that location availability is managed per-location.
- **Bonus fix:** Added `heroImageUrl` prop to `ProductDetailClient` to resolve a pre-existing TypeScript error introduced by the prior PR (#116) that was blocking the pre-commit typecheck hook.

## Agent
Worked by: worker agent (inline)

---
Generated by BrewCortex worker agent