### PR TITLE
feat: product variant type system and inventory pricing schema

### DIFF
--- a/docs/engineering/admin.md
+++ b/docs/engineering/admin.md
@@ -174,3 +174,6 @@ flowchart LR
 - Inventory writes now append an immutable adjustment log at
   `inventory/{locationId}/items/{productId}/adjustments/{adjustmentId}` in the same batch as the item write.
 - Adjustment payload includes before/after snapshots (`previous*`/`next*`), computed delta (`deltaQuantity`), `changedFields`, `reason`, `source`, `updatedBy`, and `createdAt`.
+- `InventoryItem.variantPricing` is a map of `variantId → { price, compareAtPrice?, inStock? }`. Keys correspond to `ProductVariant.variantId` values from `Product.variants`. Pricing is per-location — the same product can have different prices at hub vs. retail.
+- `setInventoryItem` accepts `variantPricing` in the patch object. When present, it is merged atomically with the item write and `'variantPricing'` is added to `changedFields` in the audit record.
+- The `'price-update'` reason is available in `InventoryAdjustmentReason` for pricing-only audit records.

--- a/docs/engineering/products.md
+++ b/docs/engineering/products.md
@@ -174,3 +174,21 @@ The product detail page renders the "Lab Results / COA" accordion section only w
 | `listProductsByCategory(cat)`    | `ProductSummary[]` | Category-filtered storefront pages                    |
 | `upsertProduct(data)`            | `string` (slug)    | Create or update a product (merge semantics)          |
 | `setProductStatus(slug, status)` | `void`             | Compliance/admin status changes                       |
+
+---
+
+## `ProductVariant` Interface
+
+Defined in `src/types/product.ts`. Variants are authored at the product level and represent purchasable size/dose options (e.g. "1/8 oz", "10mg gummy"). Pricing is managed at the inventory level via `InventoryItem.variantPricing`.
+
+| Field       | Type                                      | Required | Purpose                      |
+| ----------- | ----------------------------------------- | -------- | ---------------------------- |
+| `variantId` | `string`                                  | Yes      | Unique within the product    |
+| `label`     | `string`                                  | Yes      | Display text, e.g. "1/8 oz"  |
+| `weight`    | `{ value: number; unit: 'g' \| 'oz' }?`   | No       | Physical weight              |
+| `quantity`  | `number?`                                 | No       | Unit count (e.g. 10 gummies) |
+| `dose`      | `{ value: number; unit: 'mg' \| 'mcg' }?` | No       | Per-serving dose             |
+
+`docToVariants()` maps the `variants` array defensively — entries missing `variantId` or `label` are silently skipped. Returns `undefined` (not `[]`) when no valid entries are found.
+
+> Note: `src/constants/product-variants.ts` exports `CategoryVariant` (formerly `ProductVariant`), which represents UI-level display options for the storefront variant selector. These are separate from `ProductVariant` in `src/types/product.ts`.

--- a/src/constants/product-variants.ts
+++ b/src/constants/product-variants.ts
@@ -1,9 +1,15 @@
-export interface ProductVariant {
+/**
+ * CategoryVariant — represents a UI-level variant option for a product category
+ * (e.g. "1/8 oz", "10-pack"). These are display constants for the storefront
+ * variant selector; they differ from ProductVariant in src/types/product.ts,
+ * which represents a Firestore-persisted product variant with pricing/dose data.
+ */
+export interface CategoryVariant {
   key: string;
   label: string;
 }
 
-const FLOWER_VARIANTS: ProductVariant[] = [
+const FLOWER_VARIANTS: CategoryVariant[] = [
   { key: 'preroll', label: 'Preroll' },
   { key: 'eighth', label: '1/8 oz' },
   { key: 'quarter', label: '1/4 oz' },
@@ -11,28 +17,28 @@ const FLOWER_VARIANTS: ProductVariant[] = [
   { key: 'ounce', label: '1 oz' },
 ];
 
-const EDIBLE_VARIANTS: ProductVariant[] = [
+const EDIBLE_VARIANTS: CategoryVariant[] = [
   { key: 'single', label: '1pc' },
   { key: 'five-pack', label: '5-pack' },
   { key: 'ten-pack', label: '10-pack' },
 ];
 
-const DRINK_VARIANTS: ProductVariant[] = [
+const DRINK_VARIANTS: CategoryVariant[] = [
   { key: 'single', label: 'Single Can' },
   { key: 'two-pack', label: '2-pack' },
 ];
 
-const CONCENTRATE_VARIANTS: ProductVariant[] = [
+const CONCENTRATE_VARIANTS: CategoryVariant[] = [
   { key: 'half-gram', label: '0.5g' },
   { key: 'gram', label: '1g' },
 ];
 
-const VAPE_VARIANTS: ProductVariant[] = [
+const VAPE_VARIANTS: CategoryVariant[] = [
   { key: 'single', label: 'Single Cart' },
   { key: 'two-pack', label: '2-pack' },
 ];
 
-const VARIANT_MAP: Record<string, ProductVariant[]> = {
+const VARIANT_MAP: Record<string, CategoryVariant[]> = {
   flower: FLOWER_VARIANTS,
   edibles: EDIBLE_VARIANTS,
   drinks: DRINK_VARIANTS,
@@ -48,7 +54,7 @@ const SIZE_LABEL_MAP: Record<string, string> = {
   vapes: 'Select Quantity',
 };
 
-export function getVariantsForCategory(category: string): ProductVariant[] {
+export function getVariantsForCategory(category: string): CategoryVariant[] {
   return VARIANT_MAP[category] ?? FLOWER_VARIANTS;
 }
 

--- a/src/lib/repositories/inventory.repository.ts
+++ b/src/lib/repositories/inventory.repository.ts
@@ -88,6 +88,7 @@ export async function listOnlineAvailableInventory(): Promise<
       availablePickup: false,
       featured: d.featured ?? false,
       quantity: d.quantity ?? undefined,
+      variantPricing: docToVariantPricing(d.variantPricing),
     } satisfies InventoryItemSummary;
   });
 }
@@ -118,6 +119,7 @@ export async function listFeaturedInventory(
       availablePickup: d.availablePickup ?? false,
       featured: true,
       quantity: d.quantity ?? undefined,
+      variantPricing: docToVariantPricing(d.variantPricing),
     } satisfies InventoryItemSummary;
   });
 }
@@ -147,6 +149,8 @@ export async function setInventoryItem(
     quantity?: number;
     notes?: string;
     updatedBy?: string;
+    /** Partial variantPricing update — merged with existing pricing at the Firestore level */
+    variantPricing?: InventoryItem['variantPricing'];
   },
   adjustment?: {
     reason: InventoryAdjustmentReason;
@@ -218,6 +222,9 @@ export async function setInventoryItem(
     availablePickup: nextAvailablePickup,
     featured: nextFeatured,
     ...(patch.notes !== undefined && { notes: patch.notes }),
+    ...(patch.variantPricing !== undefined && {
+      variantPricing: patch.variantPricing,
+    }),
     ...(effectiveUpdatedBy !== undefined && { updatedBy: effectiveUpdatedBy }),
     updatedAt: now,
   };
@@ -237,6 +244,8 @@ export async function setInventoryItem(
       patch.notes !== (current?.notes ?? undefined)
     )
       changedFields.push('notes');
+    if (patch.variantPricing !== undefined)
+      changedFields.push('variantPricing');
 
     // Atomic write: item update + immutable audit log entry in one batch.
     const logRef = itemRef.collection('adjustments').doc();
@@ -291,10 +300,39 @@ function docToInventoryItem(
     // featured requires inStock; for hub it also requires availableOnline
     featured: inStock ? (d.featured ?? false) : false,
     quantity,
+    variantPricing: docToVariantPricing(d.variantPricing),
     notes: d.notes ?? undefined,
     updatedAt: toDate(d.updatedAt),
     updatedBy: d.updatedBy ?? undefined,
   };
+}
+
+/**
+ * Defensively maps variantPricing from Firestore.
+ * Entries with non-numeric price are silently skipped.
+ * Returns undefined if the field is absent or contains no valid entries.
+ */
+function docToVariantPricing(
+  raw: unknown
+): InventoryItem['variantPricing'] | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const result: NonNullable<InventoryItem['variantPricing']> = {};
+  let hasEntry = false;
+  for (const [variantId, entry] of Object.entries(
+    raw as Record<string, unknown>
+  )) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.price !== 'number') continue;
+    result[variantId] = {
+      price: e.price,
+      compareAtPrice:
+        typeof e.compareAtPrice === 'number' ? e.compareAtPrice : undefined,
+      inStock: typeof e.inStock === 'boolean' ? e.inStock : undefined,
+    };
+    hasEntry = true;
+  }
+  return hasEntry ? result : undefined;
 }
 
 function normalizeQuantity(value: unknown, fallbackInStock: boolean): number {

--- a/src/lib/repositories/product.repository.ts
+++ b/src/lib/repositories/product.repository.ts
@@ -5,6 +5,7 @@
 import { getAdminFirestore, toDate } from '@/lib/firebase/admin';
 import type {
   Product,
+  ProductVariant,
   ProductSummary,
   LabResults,
   ProductStrain,
@@ -182,6 +183,7 @@ function docToProduct(id: string, d: FirebaseFirestore.DocumentData): Product {
         : undefined,
     effects: Array.isArray(d.effects) ? (d.effects as string[]) : undefined,
     flavors: Array.isArray(d.flavors) ? (d.flavors as string[]) : undefined,
+    variants: docToVariants(d.variants),
     createdAt: toDate(d.createdAt),
     updatedAt: toDate(d.updatedAt),
   } satisfies Product;
@@ -199,6 +201,45 @@ function docToLabResults(
     testDate: typeof r.testDate === 'string' ? r.testDate : undefined,
     labName: typeof r.labName === 'string' ? r.labName : undefined,
   };
+}
+
+/**
+ * Defensively maps the variants array from Firestore.
+ * Entries missing required fields (variantId, label) are silently skipped.
+ */
+function docToVariants(raw: unknown): ProductVariant[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const valid: ProductVariant[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const v = item as Record<string, unknown>;
+    if (typeof v.variantId !== 'string' || typeof v.label !== 'string')
+      continue;
+    const variant: ProductVariant = {
+      variantId: v.variantId,
+      label: v.label,
+    };
+    if (v.weight && typeof v.weight === 'object') {
+      const w = v.weight as Record<string, unknown>;
+      if (typeof w.value === 'number' && (w.unit === 'g' || w.unit === 'oz')) {
+        variant.weight = { value: w.value, unit: w.unit };
+      }
+    }
+    if (typeof v.quantity === 'number') {
+      variant.quantity = v.quantity;
+    }
+    if (v.dose && typeof v.dose === 'object') {
+      const dose = v.dose as Record<string, unknown>;
+      if (
+        typeof dose.value === 'number' &&
+        (dose.unit === 'mg' || dose.unit === 'mcg')
+      ) {
+        variant.dose = { value: dose.value, unit: dose.unit };
+      }
+    }
+    valid.push(variant);
+  }
+  return valid.length > 0 ? valid : undefined;
 }
 
 function stripUndefinedFields<T extends Record<string, unknown>>(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export type {
 } from './location';
 export type {
   Product,
+  ProductVariant,
   ProductSummary,
   ProductStatus,
   LabResults,

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -32,6 +32,18 @@ export interface InventoryItem {
   featured: boolean;
   /** Optional unit count — for future staff-facing stock level display */
   quantity?: number;
+  /**
+   * Per-variant pricing for this product at this location.
+   * Keys are variantId values from Product.variants.
+   * Missing variantId means no price has been set for that variant.
+   */
+  variantPricing?: {
+    [variantId: string]: {
+      price: number;
+      compareAtPrice?: number;
+      inStock?: boolean;
+    };
+  };
   /** Admin freetext — e.g. "waiting on restock", "holds only" */
   notes?: string;
   updatedAt: Date;
@@ -48,6 +60,7 @@ export type InventoryItemSummary = Pick<
   | 'availablePickup'
   | 'featured'
   | 'quantity'
+  | 'variantPricing'
 >;
 
 export type InventoryAdjustmentReason =
@@ -57,7 +70,8 @@ export type InventoryAdjustmentReason =
   | 'toggle-pickup'
   | 'toggle-featured'
   | 'system-sync'
-  | 'correction';
+  | 'correction'
+  | 'price-update';
 
 export type InventoryAdjustmentSource = 'admin-ui' | 'system' | 'api';
 
@@ -78,6 +92,7 @@ export interface InventoryAdjustment {
     | 'availablePickup'
     | 'featured'
     | 'notes'
+    | 'variantPricing'
   >;
   previousQuantity: number;
   nextQuantity: number;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -16,11 +16,25 @@ export interface LabResults {
 }
 
 /**
+ * A single purchasable variant of a product (e.g. "1/8 oz", "10mg gummy").
+ * Variants are authored at the product level and priced at the inventory level
+ * via InventoryItem.variantPricing.
+ */
+export interface ProductVariant {
+  variantId: string;
+  label: string;
+  weight?: { value: number; unit: 'g' | 'oz' };
+  quantity?: number;
+  dose?: { value: number; unit: 'mg' | 'mcg' };
+}
+
+/**
  * Firestore document shape for a product.
  * Lives at: products/{slug}
  *
  * Visibility and featuring are controlled at the inventory level
  * (inventory/{locationId}/items/{productId}.featured), not here.
+ * Pricing is controlled at the inventory level via InventoryItem.variantPricing.
  */
 export interface Product {
   /** Firestore document ID (same as slug) */
@@ -56,6 +70,11 @@ export interface Product {
   effects?: string[];
   /** Flavor descriptors, e.g. ['Citrus', 'Pine', 'Earthy'] */
   flavors?: string[];
+  /**
+   * Purchasable size/dose variants for this product.
+   * Priced per-variant at the inventory level via InventoryItem.variantPricing.
+   */
+  variants?: ProductVariant[];
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
Closes #132, Closes #133

## Summary

- **#132** — Added `ProductVariant` interface to `src/types/product.ts` with `variantId`, `label`, `weight`, `quantity`, and `dose` fields. Added `variants?: ProductVariant[]` to `Product`. Added `docToVariants()` defensive mapper in `product.repository.ts` (invalid entries silently skipped). Renamed `ProductVariant` → `CategoryVariant` in `src/constants/product-variants.ts` to avoid namespace collision (file preserved for #138). Exported `ProductVariant` from the types barrel.

- **#133** — Added `variantPricing?: { [variantId: string]: { price, compareAtPrice?, inStock? } }` to `InventoryItem` and `InventoryItemSummary`. Added `docToVariantPricing()` defensive mapper. `setInventoryItem` now accepts `variantPricing` in the patch object, writes it atomically, and records `'variantPricing'` in `changedFields`. Added `'price-update'` to `InventoryAdjustmentReason`. Updated `listOnlineAvailableInventory` and `listFeaturedInventory` to include `variantPricing` on returned summaries.

## Files changed

| File | Change |
|------|--------|
| `src/types/product.ts` | Add `ProductVariant`, `variants` on `Product` |
| `src/types/inventory.ts` | Add `variantPricing`, `price-update` reason, `variantPricing` in `changedFields` |
| `src/types/index.ts` | Export `ProductVariant` |
| `src/lib/repositories/product.repository.ts` | Add `docToVariants()`, map `variants` in `docToProduct` |
| `src/lib/repositories/inventory.repository.ts` | Add `docToVariantPricing()`, `variantPricing` in patch/summaries |
| `src/constants/product-variants.ts` | Rename `ProductVariant` → `CategoryVariant` |
| `docs/engineering/products.md` | Document `ProductVariant` interface |
| `docs/engineering/admin.md` | Document `variantPricing` semantics |

TypeScript strict mode passes. All inventory repository tests pass (36/36).

---
Generated by BrewCortex worker agent