### PR TITLE
feat: cart and checkout design QA pass

### DIFF
--- a/src/components/AddToCartButton/AddToCartButton.css
+++ b/src/components/AddToCartButton/AddToCartButton.css
@@ -1,0 +1,19 @@
+/* AddToCartButton styles
+   All values use Asymmetry design system tokens. No raw hex or rem. */
+
+.add-to-cart-btn {
+  /* Smooth transition between default and confirmed states */
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+/* Added confirmation state */
+.add-to-cart-btn--added,
+.add-to-cart-btn--added:hover {
+  background-color: var(--color-success-bg);
+  border-color: var(--color-success);
+  color: var(--color-success);
+  cursor: default;
+}

--- a/src/components/AddToCartButton/index.tsx
+++ b/src/components/AddToCartButton/index.tsx
@@ -10,8 +10,10 @@
  * This component does NOT derive pricing or availability internally.
  */
 
+import { useState, useCallback } from 'react';
 import { useCart } from '@/contexts/CartContext';
 import type { DisplayVariant } from '@/lib/storefront/resolveVariantPricing';
+import './AddToCartButton.css';
 
 interface AddToCartButtonProps {
   productId: string;
@@ -26,6 +28,9 @@ interface AddToCartButtonProps {
   className?: string;
 }
 
+/** Duration of the confirmation feedback state in milliseconds */
+const CONFIRM_DURATION_MS = 1_500;
+
 export function AddToCartButton({
   productId,
   productName,
@@ -35,10 +40,11 @@ export function AddToCartButton({
   className,
 }: AddToCartButtonProps) {
   const { addItem } = useCart();
+  const [added, setAdded] = useState(false);
 
   const disabled = !selectedVariant || !selectedVariant.inStock;
 
-  function handleAdd() {
+  const handleAdd = useCallback(() => {
     if (!selectedVariant) return;
     addItem({
       productId,
@@ -48,7 +54,17 @@ export function AddToCartButton({
       unitPrice: selectedVariant.price,
       image: productImage,
     });
-  }
+    setAdded(true);
+    setTimeout(() => setAdded(false), CONFIRM_DURATION_MS);
+  }, [addItem, productId, productName, productImage, selectedVariant]);
+
+  const label = !selectedVariant
+    ? 'Select a variant'
+    : !selectedVariant.inStock
+      ? 'Out of Stock'
+      : added
+        ? 'Added ✓'
+        : 'Add to Cart';
 
   return (
     <div
@@ -56,21 +72,20 @@ export function AddToCartButton({
     >
       <button
         type="button"
-        className={`btn btn-primary add-to-cart-btn${className ? ` ${className}` : ''}`}
+        className={`btn btn-primary add-to-cart-btn${added ? ' add-to-cart-btn--added' : ''}${className ? ` ${className}` : ''}`}
         onClick={handleAdd}
-        disabled={disabled}
-        aria-disabled={disabled}
+        disabled={disabled || added}
+        aria-disabled={disabled || added}
+        aria-live="polite"
         aria-label={
           selectedVariant
-            ? `Add ${productName} — ${selectedVariant.label} to cart`
+            ? added
+              ? `${productName} added to cart`
+              : `Add ${productName} — ${selectedVariant.label} to cart`
             : 'Select a variant to add to cart'
         }
       >
-        {!selectedVariant
-          ? 'Select a variant'
-          : !selectedVariant.inStock
-            ? 'Out of Stock'
-            : 'Add to Cart'}
+        {label}
       </button>
     </div>
   );


### PR DESCRIPTION
Closes #130

## What

Design QA pass on the cart and checkout components shipped in PR #131.

**AddToCartButton — "Added ✓" confirmation state**
- Added `added` state with 1.5s feedback window after a successful add
- Button label transitions: `Add to Cart` → `Added ✓` → `Add to Cart`
- Button disabled during feedback window to prevent duplicate adds
- CSS transition on `background-color`, `border-color`, and `color` for smooth visual cue
- `aria-live="polite"` added so screen readers announce the state change
- Dynamic `aria-label` updates to `"{name} added to cart"` on confirmation
- New `AddToCartButton.css` — all values use design system tokens only (`--color-success-bg`, `--color-success`); no raw hex or rem

**Audit: no changes needed (already correct on main)**
- `CartDrawer` — slide-in animation via `@keyframes slideInFromRight` (0.25s ease-out) confirmed present
- Z-index stack — CartDrawer (200/201) above nav ceiling (120), no conflicts
- `cart.css` and `CartDrawer.css` — full token audit, zero raw hex/rem values found
- `formatCents()` — confirmed used consistently across cart page, order page, and CartDrawer
- `/order/[id]` — all four states (pending/processing, paid, failed, voided/refunded) rendered with correct CSS classes and on-brand styling
- Button classes — `btn-primary` / `btn-secondary` (flat) used correctly; no `btn--primary` double-dash variants

## Agent

Worked by: worker agent

---
Generated by BrewCortex worker agent