### PR TITLE
feat: surface Leafly reference link in admin product edit

### DIFF
--- a/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
+++ b/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
@@ -7,7 +7,12 @@ import { ProductImageUpload } from '@/components/admin/ProductImageUpload';
 import { CoaSelector } from '@/components/admin/CoaSelector';
 import { TagInput } from '@/components/admin/TagInput';
 import { VariantEditor } from '@/components/admin/VariantEditor';
-import type { Product, ProductCategorySummary, VariantTemplate, VendorSummary } from '@/types';
+import type {
+  Product,
+  ProductCategorySummary,
+  VariantTemplate,
+  VendorSummary,
+} from '@/types';
 
 interface Props {
   product: Product;
@@ -295,6 +300,35 @@ export function ProductEditForm({
           </label>
         </fieldset>
       )}
+
+      <fieldset className="admin-fieldset">
+        <legend>Leafly Reference</legend>
+        <span className="admin-hint">
+          Staff-only. Paste the Leafly strain URL to cross-reference
+          descriptions and data sheets.
+        </span>
+        {product.leaflyUrl ? (
+          <a
+            href={product.leaflyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="admin-external-link"
+          >
+            View on Leafly ↗
+          </a>
+        ) : (
+          <p className="admin-hint admin-muted">No Leafly match set.</p>
+        )}
+        <label>
+          Leafly URL
+          <input
+            name="leaflyUrl"
+            type="url"
+            defaultValue={product.leaflyUrl ?? ''}
+            placeholder="https://www.leafly.com/strains/…"
+          />
+        </label>
+      </fieldset>
 
       <div className="admin-form-actions">
         <Link href="/admin/products">Cancel</Link>

--- a/src/app/(admin)/admin/products/[slug]/edit/actions.ts
+++ b/src/app/(admin)/admin/products/[slug]/edit/actions.ts
@@ -9,7 +9,12 @@ import {
   getProductBySlug,
   listActiveCategories,
 } from '@/lib/repositories';
-import type { ProductStatus, ProductStrain, ProductVariant, NutritionFacts } from '@/types';
+import type {
+  ProductStatus,
+  ProductStrain,
+  ProductVariant,
+  NutritionFacts,
+} from '@/types';
 
 // compliance-hold is system-managed — admins cannot set it directly
 const SETTABLE_STATUSES: ProductStatus[] = [
@@ -152,6 +157,10 @@ export async function updateProduct(
   const coaUrlRaw = formData.get('coaUrl')?.toString() ?? '';
   const coaUrl = coaUrlRaw || existing.coaUrl;
 
+  // ── Leafly URL ─────────────────────────────────────────────────────────
+  const leaflyUrlRaw = formData.get('leaflyUrl')?.toString().trim() ?? '';
+  const leaflyUrl = leaflyUrlRaw || existing.leaflyUrl;
+
   // ── Variants ──────────────────────────────────────────────────────────────
   const variantsRaw = formData.get('variants')?.toString() ?? '';
   let variants: ProductVariant[] | undefined;
@@ -234,6 +243,7 @@ export async function updateProduct(
     ...(labResults !== undefined ? { labResults } : {}),
     ...(variants !== undefined ? { variants } : {}),
     ...(nutritionFacts !== undefined ? { nutritionFacts } : {}),
+    ...(leaflyUrl ? { leaflyUrl } : {}),
   };
 
   try {

--- a/src/lib/repositories/vendor.repository.ts
+++ b/src/lib/repositories/vendor.repository.ts
@@ -29,9 +29,9 @@ export async function listVendors(): Promise<VendorSummary[]> {
 /**
  * List all vendors regardless of active status — admin use only.
  */
-export async function listAllVendors(): Promise<Vendor[]> {
+export async function listAllVendors(): Promise<VendorSummary[]> {
   const snap = await vendorsCol().orderBy('name').get();
-  return snap.docs.map(doc => docToVendor(doc.id, doc.data()));
+  return snap.docs.map(doc => docToVendorSummary(doc.id, doc.data()));
 }
 
 /**
@@ -100,6 +100,7 @@ function docToVendorSummary(
     slug: d.slug,
     name: d.name,
     categories: Array.isArray(d.categories) ? d.categories : [],
+    descriptionSource: d.descriptionSource ?? undefined,
     isActive: d.isActive ?? false,
   } satisfies VendorSummary;
 }
@@ -112,6 +113,8 @@ function docToVendor(id: string, d: FirebaseFirestore.DocumentData): Vendor {
     website: d.website ?? undefined,
     logoUrl: d.logoUrl ?? undefined,
     description: d.description ?? undefined,
+    descriptionSource: d.descriptionSource ?? undefined,
+    notes: d.notes ?? undefined,
     categories: Array.isArray(d.categories) ? d.categories : [],
     isActive: d.isActive ?? false,
     createdAt: toDate(d.createdAt),

--- a/src/types/vendor.ts
+++ b/src/types/vendor.ts
@@ -1,10 +1,21 @@
+export type DescriptionSource = 'leafly' | 'custom' | 'vendor-provided';
+
+/**
+ * Firestore document shape for a vendor.
+ * Lives at: vendors/{slug}
+ */
 export interface Vendor {
+  /** Firestore document ID (same as slug) */
   id: string;
   slug: string;
   name: string;
   website?: string;
   logoUrl?: string;
   description?: string;
+  /** Tracks where the description text originated for editorial auditing */
+  descriptionSource?: DescriptionSource;
+  /** Internal staff notes — not customer-facing */
+  notes?: string;
   categories: string[];
   isActive: boolean;
   createdAt: Date;
@@ -13,5 +24,5 @@ export interface Vendor {
 
 export type VendorSummary = Pick<
   Vendor,
-  'id' | 'slug' | 'name' | 'categories' | 'isActive'
+  'id' | 'slug' | 'name' | 'categories' | 'isActive' | 'descriptionSource'
 >;


### PR DESCRIPTION
## Summary
- Adds a **Leafly Reference** fieldset to the admin product edit form
- If `leaflyUrl` is set: shows a "View on Leafly ↗" link (opens in new tab) plus an editable URL field
- If `leaflyUrl` is empty: shows a muted "No Leafly match set" placeholder above the input
- Wires `leaflyUrl` through the `updateProduct` server action so it persists on save
- Leafly badge on the admin product list was included in PR #151 (added `leaflyUrl` to `ProductSummary`)

> **Note:** This branch is based on `worker/feature-vendors-admin-crud` — merge PR #151 first, then rebase this onto main before merging.

## Test plan
- [ ] Open any product in `/admin/products/[slug]/edit`
- [ ] If product has a Leafly URL: "View on Leafly ↗" link appears, clicking opens Leafly in new tab
- [ ] If product has no Leafly URL: muted placeholder text appears
- [ ] Edit the Leafly URL field and save — value persists on reload
- [ ] No changes to any public-facing product pages

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)