### PR TITLE
feat: public vendor pages — directory + detail

### DIFF
--- a/docs/engineering/vendors.md
+++ b/docs/engineering/vendors.md
@@ -1,0 +1,47 @@
+# Vendors — Engineering Reference
+
+> Last updated: 2026-04-17
+
+## Firestore collection
+
+`vendors/{slug}` — see src/types/vendor.ts for the full document shape.
+
+Key fields:
+
+- `isActive` (boolean) — only active vendors are shown on public pages
+- `website` (string, optional) — external brand URL; rendered with rel="noopener noreferrer"
+- `logoUrl` (string, optional) — Firebase Storage path; rendered as placeholder if absent
+- `categories` (string[]) — category tags (edibles, vapes, etc.)
+- `description` (string, optional) — public-facing vendor bio
+
+## Repository
+
+`src/lib/repositories/vendor.repository.ts`
+
+| Function                          | Description                                                          |
+| --------------------------------- | -------------------------------------------------------------------- |
+| `listVendors()`                   | Active vendors only, ordered by name — used by public directory page |
+| `listAllVendors()`                | All vendors regardless of status — admin use only                    |
+| `getVendorBySlug(slug)`           | Single vendor by slug; returns null if not found                     |
+| `upsertVendor(data)`              | Create or update; preserves createdAt on update                      |
+| `setVendorActive(slug, isActive)` | Toggle active flag                                                   |
+
+## Public pages
+
+| Route             | File                                           |
+| ----------------- | ---------------------------------------------- |
+| `/vendors`        | `src/app/(storefront)/vendors/page.tsx`        |
+| `/vendors/[slug]` | `src/app/(storefront)/vendors/[slug]/page.tsx` |
+
+Both pages use `revalidate = 3600` (ISR, 1-hour cache).
+
+The detail page (`/vendors/[slug]`):
+
+- Calls `notFound()` if vendor is missing OR `isActive === false`
+- Renders a product grid via `listProductsByVendor()` (see products.md)
+- Shows a friendly empty state when no active products exist
+- External website link uses `target="_blank" rel="noopener noreferrer"`
+
+## Navigation
+
+Vendors directory is linked from the site footer (`src/components/Footer/Footer.tsx`).

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -27,6 +27,15 @@
       ]
     },
     {
+      "collectionGroup": "products",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "vendorSlug", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "promos",
       "queryScope": "COLLECTION",
       "fields": [

--- a/src/app/(admin)/admin/products/[slug]/edit/actions.ts
+++ b/src/app/(admin)/admin/products/[slug]/edit/actions.ts
@@ -44,6 +44,7 @@ export async function updateProduct(
   const category = formData.get('category')?.toString();
   const details = formData.get('details')?.toString().trim();
   const status = formData.get('status')?.toString() as ProductStatus;
+  const vendorSlug = formData.get('vendorSlug')?.toString() || undefined;
   const federalDeadlineRisk = formData.get('federalDeadlineRisk') === 'true';
   const availableAt = formData.getAll('availableAt').map(v => v.toString());
 
@@ -244,6 +245,7 @@ export async function updateProduct(
     ...(variants !== undefined ? { variants } : {}),
     ...(nutritionFacts !== undefined ? { nutritionFacts } : {}),
     ...(leaflyUrl ? { leaflyUrl } : {}),
+    ...(vendorSlug ? { vendorSlug } : {}),
   };
 
   try {

--- a/src/app/(admin)/admin/products/new/ProductCreateForm.tsx
+++ b/src/app/(admin)/admin/products/new/ProductCreateForm.tsx
@@ -8,14 +8,23 @@ import { ProductImageUpload } from '@/components/admin/ProductImageUpload';
 import { CoaSelector } from '@/components/admin/CoaSelector';
 import { TagInput } from '@/components/admin/TagInput';
 import { VariantEditor } from '@/components/admin/VariantEditor';
-import type { ProductCategorySummary, VariantTemplate } from '@/types';
+import type {
+  ProductCategorySummary,
+  VariantTemplate,
+  VendorSummary,
+} from '@/types';
 
 interface Props {
   categories: ProductCategorySummary[];
   variantTemplates: VariantTemplate[];
+  vendors: VendorSummary[];
 }
 
-export function ProductCreateForm({ categories, variantTemplates }: Props) {
+export function ProductCreateForm({
+  categories,
+  variantTemplates,
+  vendors,
+}: Props) {
   const [state, formAction, pending] = useActionState(createProduct, null);
   const [slug, setSlug] = useState('');
   const [imageUploading, setImageUploading] = useState(false);
@@ -51,6 +60,18 @@ export function ProductCreateForm({ categories, variantTemplates }: Props) {
           {categories.map(cat => (
             <option key={cat.slug} value={cat.slug}>
               {cat.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label>
+        Vendor
+        <select name="vendorSlug">
+          <option value="">None</option>
+          {vendors.map(v => (
+            <option key={v.slug} value={v.slug}>
+              {v.name}
             </option>
           ))}
         </select>

--- a/src/app/(admin)/admin/products/new/actions.ts
+++ b/src/app/(admin)/admin/products/new/actions.ts
@@ -27,6 +27,7 @@ export async function createProduct(
   const name = formData.get('name')?.toString().trim();
   const category = formData.get('category')?.toString();
   const details = formData.get('details')?.toString().trim();
+  const vendorSlug = formData.get('vendorSlug')?.toString() || undefined;
   const federalDeadlineRisk = formData.get('federalDeadlineRisk') === 'true';
   const availableAt = formData.getAll('availableAt').map(v => v.toString());
 
@@ -147,6 +148,7 @@ export async function createProduct(
     ...(flavors !== undefined ? { flavors } : {}),
     ...(labResults !== undefined ? { labResults } : {}),
     ...(variants !== undefined ? { variants } : {}),
+    ...(vendorSlug ? { vendorSlug } : {}),
   });
 
   revalidatePath('/admin/products');

--- a/src/app/(admin)/admin/products/new/page.tsx
+++ b/src/app/(admin)/admin/products/new/page.tsx
@@ -1,15 +1,20 @@
 export const dynamic = 'force-dynamic';
 
 import { requireRole } from '@/lib/admin-auth';
-import { listActiveCategories, listVariantTemplates } from '@/lib/repositories';
+import {
+  listActiveCategories,
+  listVariantTemplates,
+  listVendors,
+} from '@/lib/repositories';
 import { ProductCreateForm } from './ProductCreateForm';
 
 export default async function NewProductPage() {
   await requireRole('staff');
 
-  const [categories, variantTemplates] = await Promise.all([
+  const [categories, variantTemplates, vendors] = await Promise.all([
     listActiveCategories(),
     listVariantTemplates(),
+    listVendors(),
   ]);
 
   return (
@@ -18,6 +23,7 @@ export default async function NewProductPage() {
       <ProductCreateForm
         categories={categories}
         variantTemplates={variantTemplates}
+        vendors={vendors}
       />
     </>
   );

--- a/src/app/(storefront)/vendors/[slug]/page.tsx
+++ b/src/app/(storefront)/vendors/[slug]/page.tsx
@@ -1,0 +1,117 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { Card } from '@/components/Card';
+import { CardGrid } from '@/components/CardGrid';
+import { ProductImage } from '@/components/ProductImage';
+import { buildMetadata } from '@/lib/seo/metadata.factory';
+import { getVendorBySlug, listProductsByVendor } from '@/lib/repositories';
+import { seoConfig } from '@/config/seo.config';
+
+export const revalidate = 3600;
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Props) {
+  const { slug } = await params;
+  const vendor = await getVendorBySlug(slug);
+  if (!vendor) return {};
+
+  return buildMetadata('/vendors/[slug]', {
+    title: `${vendor.name} Products | Rush N Relax`,
+    description:
+      vendor.description ??
+      `Browse ${vendor.name} products available at Rush N Relax dispensaries in East Tennessee.`,
+    canonical: `${seoConfig.site.domain}/vendors/${slug}`,
+    path: `/vendors/${slug}`,
+  });
+}
+
+export default async function VendorDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const [vendor, products] = await Promise.all([
+    getVendorBySlug(slug),
+    listProductsByVendor(slug),
+  ]);
+
+  if (!vendor || !vendor.isActive) notFound();
+
+  return (
+    <main className="vendor-detail-page">
+      <section className="vendor-detail-hero asymmetry-section-stable page-hero-shell">
+        <div className="container">
+          <nav className="vendor-breadcrumb" aria-label="Breadcrumb">
+            <Link href="/vendors">Our Vendors</Link>
+            <span aria-hidden="true"> / </span>
+            <span>{vendor.name}</span>
+          </nav>
+
+          <h1>{vendor.name}</h1>
+
+          {vendor.categories.length > 0 && (
+            <div className="vendor-detail-categories">
+              {vendor.categories.map((cat: string) => (
+                <span key={cat} className="vendor-category-tag">
+                  {cat}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {vendor.description && <p className="lead">{vendor.description}</p>}
+
+          {vendor.website && (
+            <a
+              href={vendor.website}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn vendor-website-btn"
+            >
+              Visit {vendor.name}&apos;s Website →
+            </a>
+          )}
+        </div>
+      </section>
+
+      <section className="vendor-products asymmetry-section-anchor">
+        <div className="container">
+          <h2>Products by {vendor.name}</h2>
+
+          {products.length === 0 ? (
+            <p className="text-secondary vendor-empty-state">
+              No products from {vendor.name} are currently available. Check back
+              soon.
+            </p>
+          ) : (
+            <CardGrid columns="auto" gap="lg">
+              {products.map(
+                (product: import('@/types').ProductSummary, index: number) => (
+                  <Card
+                    key={product.id}
+                    variant="product"
+                    to={`/products/${product.slug}`}
+                    surface={index % 3 === 1 ? 'anchor' : 'stable'}
+                    elevation={index % 3 === 1 ? 'soft' : 'none'}
+                    motion={index % 3 === 1}
+                  >
+                    <ProductImage
+                      slug={product.slug}
+                      alt={product.name}
+                      path={product.image}
+                    />
+                    <div className="product-card-content">
+                      <div className="product-category">{product.category}</div>
+                      <h3>{product.name}</h3>
+                      <div className="product-card-cta">View Details →</div>
+                    </div>
+                  </Card>
+                )
+              )}
+            </CardGrid>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(storefront)/vendors/page.tsx
+++ b/src/app/(storefront)/vendors/page.tsx
@@ -1,6 +1,7 @@
-import Link from 'next/link';
 import { buildMetadata } from '@/lib/seo/metadata.factory';
 import { listVendors } from '@/lib/repositories';
+import { Card } from '@/components/Card';
+import { CardGrid } from '@/components/CardGrid';
 
 export const revalidate = 3600;
 
@@ -33,20 +34,16 @@ export default async function VendorsPage() {
               No vendors listed yet — check back soon.
             </p>
           ) : (
-            <div className="vendors-grid">
+            <CardGrid columns="3" gap="lg">
               {vendors.map(
                 (vendor: import('@/types').VendorSummary, index: number) => (
-                  <Link
+                  <Card
                     key={vendor.slug}
-                    href={`/vendors/${vendor.slug}`}
-                    className={[
-                      'rnr-card',
-                      'rnr-card--product',
-                      index % 3 === 1
-                        ? 'rnr-card--surface-anchor rnr-card--anchor rnr-card--elevation-soft rnr-card--motion'
-                        : 'rnr-card--surface-stable rnr-card--stable rnr-card--elevation-none',
-                      'vendor-card',
-                    ].join(' ')}
+                    variant="info"
+                    to={`/vendors/${vendor.slug}`}
+                    surface={index % 3 === 1 ? 'anchor' : 'stable'}
+                    elevation={index % 3 === 1 ? 'soft' : 'none'}
+                    motion={index % 3 === 1}
                   >
                     <div className="vendor-card-content">
                       <h2 className="vendor-card-name">{vendor.name}</h2>
@@ -61,10 +58,10 @@ export default async function VendorsPage() {
                       )}
                       <div className="vendor-card-cta">View Products →</div>
                     </div>
-                  </Link>
+                  </Card>
                 )
               )}
-            </div>
+            </CardGrid>
           )}
         </div>
       </section>

--- a/src/app/(storefront)/vendors/page.tsx
+++ b/src/app/(storefront)/vendors/page.tsx
@@ -17,7 +17,10 @@ export default async function VendorsPage() {
 
   return (
     <main className="vendors-page">
-      <section className="vendors-hero asymmetry-section-stable page-hero-shell">
+      <section
+        id="vendors-hero"
+        className="vendors-hero asymmetry-section-stable page-hero-shell"
+      >
         <div className="container">
           <h1>Our Vendors</h1>
           <p className="lead">
@@ -27,7 +30,10 @@ export default async function VendorsPage() {
         </div>
       </section>
 
-      <section className="vendors-directory asymmetry-section-anchor">
+      <section
+        id="vendors-directory"
+        className="vendors-directory asymmetry-section-anchor"
+      >
         <div className="container">
           {vendors.length === 0 ? (
             <p className="text-secondary">

--- a/src/app/(storefront)/vendors/page.tsx
+++ b/src/app/(storefront)/vendors/page.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import { buildMetadata } from '@/lib/seo/metadata.factory';
+import { listVendors } from '@/lib/repositories';
+
+export const revalidate = 3600;
+
+export const metadata = buildMetadata('/vendors', {
+  title: 'Our Vendors | Rush N Relax',
+  description:
+    'Meet the brands behind our shelves. Every vendor is hand-selected for quality, transparency, and lab-tested products at Rush N Relax dispensaries in East Tennessee.',
+  path: '/vendors',
+});
+
+export default async function VendorsPage() {
+  const vendors = await listVendors();
+
+  return (
+    <main className="vendors-page">
+      <section className="vendors-hero asymmetry-section-stable page-hero-shell">
+        <div className="container">
+          <h1>Our Vendors</h1>
+          <p className="lead">
+            We source from brands we trust — lab-tested, vetted, and worthy of a
+            spot on our shelves.
+          </p>
+        </div>
+      </section>
+
+      <section className="vendors-directory asymmetry-section-anchor">
+        <div className="container">
+          {vendors.length === 0 ? (
+            <p className="text-secondary">
+              No vendors listed yet — check back soon.
+            </p>
+          ) : (
+            <div className="vendors-grid">
+              {vendors.map(
+                (vendor: import('@/types').VendorSummary, index: number) => (
+                  <Link
+                    key={vendor.slug}
+                    href={`/vendors/${vendor.slug}`}
+                    className={[
+                      'rnr-card',
+                      'rnr-card--product',
+                      index % 3 === 1
+                        ? 'rnr-card--surface-anchor rnr-card--anchor rnr-card--elevation-soft rnr-card--motion'
+                        : 'rnr-card--surface-stable rnr-card--stable rnr-card--elevation-none',
+                      'vendor-card',
+                    ].join(' ')}
+                  >
+                    <div className="vendor-card-content">
+                      <h2 className="vendor-card-name">{vendor.name}</h2>
+                      {vendor.categories.length > 0 && (
+                        <div className="vendor-card-categories">
+                          {vendor.categories.map((cat: string) => (
+                            <span key={cat} className="vendor-category-tag">
+                              {cat}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                      <div className="vendor-card-cta">View Products →</div>
+                    </div>
+                  </Link>
+                )
+              )}
+            </div>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link';
 const FDA_DISCLAIMER =
   'These statements have not been evaluated by the Food and Drug Administration. This product is not intended to diagnose, treat, cure, or prevent any disease.';
 
+const SITE_LINKS = [{ label: 'Our Vendors', href: '/vendors' }] as const;
+
 const LEGAL_LINKS = [
   { label: 'Terms & Conditions', href: '/terms' },
   { label: 'Privacy Policy', href: '/privacy' },
@@ -114,6 +116,14 @@ export function Footer() {
           <AmexLogo />
           <DiscoverLogo />
         </div>
+
+        <nav className="footer-links" aria-label="Site navigation">
+          {SITE_LINKS.map(link => (
+            <Link key={link.href} href={link.href} className="footer-link">
+              {link.label}
+            </Link>
+          ))}
+        </nav>
 
         <nav className="footer-links" aria-label="Legal navigation">
           {LEGAL_LINKS.map(link => (

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -18,6 +18,7 @@ export const ROUTE_SECTIONS = {
   '/locations': ['locations-hero', 'locations-list', 'cta'],
   '/contact': ['contact-hero', 'contact-form-section', 'location-contact'],
   '/products': ['products-hero', 'products-grid'],
+  '/vendors': ['vendors-hero', 'vendors-directory'],
 } as const;
 
 export type RoutePath = keyof typeof ROUTE_SECTIONS;
@@ -49,6 +50,7 @@ export const PAGE_TO_ROUTE: Record<string, RoutePath | 'dynamic'> = {
   cart: 'dynamic',
   'order/[id]': 'dynamic',
   'promo/[slug]': 'dynamic',
+  vendors: '/vendors',
   'vendors/[slug]': 'dynamic',
   terms: 'dynamic',
   privacy: 'dynamic',

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -49,6 +49,7 @@ export const PAGE_TO_ROUTE: Record<string, RoutePath | 'dynamic'> = {
   cart: 'dynamic',
   'order/[id]': 'dynamic',
   'promo/[slug]': 'dynamic',
+  'vendors/[slug]': 'dynamic',
   terms: 'dynamic',
   privacy: 'dynamic',
   shipping: 'dynamic',

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -10,6 +10,7 @@ export {
   listProducts,
   listProductsByIds,
   listProductsByCategory,
+  listProductsByVendor,
   getProductBySlug,
   upsertProduct,
   clearProductFields,

--- a/src/lib/repositories/product.repository.ts
+++ b/src/lib/repositories/product.repository.ts
@@ -273,3 +273,19 @@ function stripUndefinedFields<T extends Record<string, unknown>>(
     Object.entries(value).filter(([, v]) => v !== undefined)
   ) as Partial<T>;
 }
+
+/**
+ * List active products for a given vendor slug.
+ * Used by the public vendor detail page.
+ */
+export async function listProductsByVendor(
+  vendorSlug: string
+): Promise<ProductSummary[]> {
+  const snap = await productsCol()
+    .where('status', '==', 'active')
+    .where('vendorSlug', '==', vendorSlug)
+    .orderBy('name')
+    .get();
+
+  return snap.docs.map(doc => docToProductSummary(doc.id, doc.data()));
+}


### PR DESCRIPTION
Closes #149

## What

- **`/vendors`** — public directory listing all active vendors as a card grid with name, categories, and "View Products →" CTA link
- **`/vendors/[slug]`** — vendor detail page with name, category tags, full description, external website link (`rel="noopener noreferrer"`), and product grid via `listProductsByVendor()`; graceful 404 if vendor missing or inactive
- **Footer** — adds "Our Vendors" site nav link
- **Repository** — adds `listProductsByVendor(vendorSlug)` to `product.repository.ts` and exports it from `index.ts`
- **Docs** — adds `docs/engineering/vendors.md` per Doc Update Rule (covers schema, repository functions, public routes, navigation)

Both pages use ISR (`revalidate = 3600`), server components only, and match the existing storefront visual style.

## Agent

Worked by: engineering (worker agent inline)

---
Generated by BrewCortex worker agent