### PR TITLE
feat: Leafly UX polish + vendors route fix

### DIFF
--- a/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
+++ b/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
@@ -331,35 +331,6 @@ export function ProductEditForm({
         </fieldset>
       )}
 
-      <fieldset className="admin-fieldset">
-        <legend>Leafly Reference</legend>
-        <span className="admin-hint">
-          Staff-only. Paste the Leafly strain URL to cross-reference
-          descriptions and data sheets.
-        </span>
-        {product.leaflyUrl ? (
-          <a
-            href={product.leaflyUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="admin-external-link"
-          >
-            View on Leafly ↗
-          </a>
-        ) : (
-          <p className="admin-hint admin-muted">No Leafly match set.</p>
-        )}
-        <label>
-          Leafly URL
-          <input
-            name="leaflyUrl"
-            type="url"
-            defaultValue={product.leaflyUrl ?? ''}
-            placeholder="https://www.leafly.com/strains/…"
-          />
-        </label>
-      </fieldset>
-
       <div className="admin-form-actions">
         <Link href="/admin/products">Cancel</Link>
         <button type="submit" disabled={pending || imageUploading}>

--- a/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
+++ b/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
@@ -7,7 +7,12 @@ import { ProductImageUpload } from '@/components/admin/ProductImageUpload';
 import { CoaSelector } from '@/components/admin/CoaSelector';
 import { TagInput } from '@/components/admin/TagInput';
 import { VariantEditor } from '@/components/admin/VariantEditor';
-import type { Product, ProductCategorySummary, VariantTemplate, VendorSummary } from '@/types';
+import type {
+  Product,
+  ProductCategorySummary,
+  VariantTemplate,
+  VendorSummary,
+} from '@/types';
 
 interface Props {
   product: Product;
@@ -34,6 +39,36 @@ export function ProductEditForm({
         Name
         <input name="name" defaultValue={product.name} required />
       </label>
+
+      <div className="admin-leafly-row">
+        <label className="admin-leafly-label">
+          Leafly URL
+          <input
+            name="leaflyUrl"
+            type="url"
+            defaultValue={product.leaflyUrl ?? ''}
+            placeholder="https://www.leafly.com/strains/…"
+          />
+        </label>
+        <a
+          href={`https://www.leafly.com/search?q=${encodeURIComponent(product.name)}&typefilter=strain`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="admin-leafly-search-btn"
+        >
+          Search Leafly ↗
+        </a>
+        {product.leaflyUrl && (
+          <a
+            href={product.leaflyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="admin-leafly-view-btn"
+          >
+            View Match ↗
+          </a>
+        )}
+      </div>
 
       <label>
         Category

--- a/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
+++ b/src/app/(admin)/admin/products/[slug]/edit/ProductEditForm.tsx
@@ -40,34 +40,34 @@ export function ProductEditForm({
         <input name="name" defaultValue={product.name} required />
       </label>
 
-      <div className="admin-leafly-row">
-        <label className="admin-leafly-label">
-          Leafly URL
+      <div className="admin-leafly-field">
+        <span className="admin-leafly-field-label">Leafly URL</span>
+        <div className="admin-leafly-row">
           <input
             name="leaflyUrl"
             type="url"
             defaultValue={product.leaflyUrl ?? ''}
             placeholder="https://www.leafly.com/strains/…"
           />
-        </label>
-        <a
-          href={`https://www.leafly.com/search?q=${encodeURIComponent(product.name)}&typefilter=strain`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="admin-leafly-search-btn"
-        >
-          Search Leafly ↗
-        </a>
-        {product.leaflyUrl && (
           <a
-            href={product.leaflyUrl}
+            href={`https://www.leafly.com/search?q=${encodeURIComponent(product.name)}&typefilter=strain`}
             target="_blank"
             rel="noopener noreferrer"
-            className="admin-leafly-view-btn"
+            className="admin-leafly-search-btn"
           >
-            View Match ↗
+            Search Leafly ↗
           </a>
-        )}
+          {product.leaflyUrl && (
+            <a
+              href={product.leaflyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="admin-leafly-view-btn"
+            >
+              View Match ↗
+            </a>
+          )}
+        </div>
       </div>
 
       <label>

--- a/src/app/(admin)/admin/products/[slug]/edit/actions.ts
+++ b/src/app/(admin)/admin/products/[slug]/edit/actions.ts
@@ -161,10 +161,6 @@ export async function updateProduct(
   const coaUrlRaw = formData.get('coaUrl')?.toString() ?? '';
   const coaUrl = coaUrlRaw || existing.coaUrl;
 
-  // ── Leafly URL ─────────────────────────────────────────────────────────
-  const leaflyUrlRaw = formData.get('leaflyUrl')?.toString().trim() ?? '';
-  const leaflyUrl = leaflyUrlRaw || existing.leaflyUrl;
-
   // ── Variants ──────────────────────────────────────────────────────────────
   const variantsRaw = formData.get('variants')?.toString() ?? '';
   let variants: ProductVariant[] | undefined;

--- a/src/app/(admin)/admin/products/[slug]/edit/actions.ts
+++ b/src/app/(admin)/admin/products/[slug]/edit/actions.ts
@@ -9,7 +9,12 @@ import {
   getProductBySlug,
   listActiveCategories,
 } from '@/lib/repositories';
-import type { ProductStatus, ProductStrain, ProductVariant, NutritionFacts } from '@/types';
+import type {
+  ProductStatus,
+  ProductStrain,
+  ProductVariant,
+  NutritionFacts,
+} from '@/types';
 
 // compliance-hold is system-managed — admins cannot set it directly
 const SETTABLE_STATUSES: ProductStatus[] = [
@@ -148,6 +153,10 @@ export async function updateProduct(
 
   const labResults = labResultsFromForm ?? existing.labResults;
 
+  // ── Leafly URL ─────────────────────────────────────────────────────────
+  const leaflyUrlRaw = formData.get('leaflyUrl')?.toString().trim() ?? '';
+  const leaflyUrl = leaflyUrlRaw || existing.leaflyUrl;
+
   // ── COA URL ────────────────────────────────────────────────────────────
   const coaUrlRaw = formData.get('coaUrl')?.toString() ?? '';
   const coaUrl = coaUrlRaw || existing.coaUrl;
@@ -234,6 +243,7 @@ export async function updateProduct(
     ...(labResults !== undefined ? { labResults } : {}),
     ...(variants !== undefined ? { variants } : {}),
     ...(nutritionFacts !== undefined ? { nutritionFacts } : {}),
+    ...(leaflyUrl ? { leaflyUrl } : {}),
   };
 
   try {

--- a/src/app/(admin)/admin/products/new/ProductCreateForm.tsx
+++ b/src/app/(admin)/admin/products/new/ProductCreateForm.tsx
@@ -18,6 +18,7 @@ interface Props {
 export function ProductCreateForm({ categories, variantTemplates }: Props) {
   const [state, formAction, pending] = useActionState(createProduct, null);
   const [slug, setSlug] = useState('');
+  const [name, setName] = useState('');
   const [imageUploading, setImageUploading] = useState(false);
 
   return (
@@ -41,8 +42,34 @@ export function ProductCreateForm({ categories, variantTemplates }: Props) {
 
       <label>
         Name
-        <input name="name" required />
+        <input
+          name="name"
+          required
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
       </label>
+
+      <div className="admin-leafly-field">
+        <span className="admin-leafly-field-label">Leafly URL</span>
+        <div className="admin-leafly-row">
+          <input
+            name="leaflyUrl"
+            type="url"
+            placeholder="https://www.leafly.com/strains/…"
+          />
+          {name && (
+            <a
+              href={`https://www.leafly.com/search?q=${encodeURIComponent(name)}&typefilter=strain`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="admin-leafly-search-btn"
+            >
+              Search Leafly ↗
+            </a>
+          )}
+        </div>
+      </div>
 
       <label>
         Category

--- a/src/app/(admin)/admin/products/new/actions.ts
+++ b/src/app/(admin)/admin/products/new/actions.ts
@@ -52,6 +52,8 @@ export async function createProduct(
   const featuredImagePath =
     formData.get('featuredImagePath')?.toString() || undefined;
 
+  const leaflyUrl = formData.get('leaflyUrl')?.toString().trim() || undefined;
+
   // ── Cannabis profile fields ────────────────────────────────────────────
   const strainRaw = formData.get('strain')?.toString() ?? '';
   const strain = VALID_STRAINS.has(strainRaw as ProductStrain)
@@ -147,6 +149,7 @@ export async function createProduct(
     ...(flavors !== undefined ? { flavors } : {}),
     ...(labResults !== undefined ? { labResults } : {}),
     ...(variants !== undefined ? { variants } : {}),
+    ...(leaflyUrl ? { leaflyUrl } : {}),
   });
 
   revalidatePath('/admin/products');

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -32,17 +32,7 @@ export default async function AdminProductsPage() {
           <tbody>
             {products.map(product => (
               <tr key={product.id} data-status={product.status}>
-                <td>
-                  {product.name}
-                  {product.leaflyUrl && (
-                    <span
-                      className="admin-badge-leafly"
-                      aria-label="Leafly match set"
-                    >
-                      Leafly
-                    </span>
-                  )}
-                </td>
+                <td>{product.name}</td>
                 <td>{product.category}</td>
                 <td>{product.status}</td>
                 <td className="admin-actions">

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -49,6 +49,7 @@ export const PAGE_TO_ROUTE: Record<string, RoutePath | 'dynamic'> = {
   cart: 'dynamic',
   'order/[id]': 'dynamic',
   'promo/[slug]': 'dynamic',
+  'vendors/[slug]': 'dynamic',
   terms: 'dynamic',
   privacy: 'dynamic',
   shipping: 'dynamic',

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -190,10 +190,17 @@
   --admin-img-upload-remove-border: 1px solid rgba(255, 127, 148, 0.4);
   --admin-img-upload-spinner-track: rgba(255, 255, 255, 0.2);
 
-  /* ── Leafly badge ──────────────────────────────────────────────────────── */
+  /* ── Leafly ────────────────────────────────────────────────────────────── */
   --admin-leafly-badge-bg: #1b5e20;
   --admin-leafly-badge-color: #a5d6a7;
   --admin-leafly-badge-margin-left: 0.5rem;
+  --admin-leafly-row-gap: 0.75rem;
+  --admin-leafly-label-gap: 0.25rem;
+  --admin-leafly-btn-padding: 0.5rem 0.75rem;
+  --admin-leafly-btn-font-size: 0.8125rem;
+  --admin-leafly-view-bg: #1b5e20;
+  --admin-leafly-view-color: #a5d6a7;
+  --admin-leafly-view-bg-hover: #2e7d32;
 
   position: relative;
   min-height: 100vh;
@@ -1377,6 +1384,57 @@
   margin-left: var(--admin-leafly-badge-margin-left);
   vertical-align: middle;
   text-transform: uppercase;
+}
+
+.admin-leafly-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--admin-leafly-row-gap);
+}
+
+.admin-leafly-label {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--admin-leafly-label-gap);
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--admin-label);
+}
+
+.admin-leafly-label input {
+  font-weight: 400;
+}
+
+.admin-leafly-search-btn,
+.admin-leafly-view-btn {
+  flex-shrink: 0;
+  padding: var(--admin-leafly-btn-padding);
+  border-radius: var(--admin-radius);
+  font-size: var(--admin-leafly-btn-font-size);
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.admin-leafly-search-btn {
+  background: var(--admin-surface-soft);
+  color: var(--admin-text);
+  border: 1px solid var(--admin-border);
+}
+
+.admin-leafly-search-btn:hover {
+  background: var(--admin-surface-hover);
+}
+
+.admin-leafly-view-btn {
+  background: var(--admin-leafly-view-bg);
+  color: var(--admin-leafly-view-color);
+  border: 1px solid transparent;
+}
+
+.admin-leafly-view-btn:hover {
+  background: var(--admin-leafly-view-bg-hover);
 }
 
 .admin-external-link {

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1386,24 +1386,27 @@
   text-transform: uppercase;
 }
 
-.admin-leafly-row {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--admin-leafly-row-gap);
-}
-
-.admin-leafly-label {
-  flex: 1;
+.admin-leafly-field {
   display: flex;
   flex-direction: column;
   gap: var(--admin-leafly-label-gap);
+  margin-bottom: var(--admin-form-label-margin-bottom);
+}
+
+.admin-leafly-field-label {
   font-weight: 600;
   font-size: 0.875rem;
   color: var(--admin-label);
 }
 
-.admin-leafly-label input {
-  font-weight: 400;
+.admin-leafly-row {
+  display: flex;
+  align-items: center;
+  gap: var(--admin-leafly-row-gap);
+}
+
+.admin-leafly-row input {
+  flex: 1;
 }
 
 .admin-leafly-search-btn,


### PR DESCRIPTION
## Summary
- Fix Leafly row layout and add Leafly URL field to product create form
- Persist leaflyUrl on product create
- Remove duplicate Leafly Reference fieldset from product edit form
- Add `vendors/[slug]` to `PAGE_TO_ROUTE` to satisfy drift detection CI test

## Test plan
- [ ] CI passes (unit tests green)
- [ ] Leafly URL field appears on product create form and saves correctly
- [ ] Product edit form shows no duplicate Leafly fieldset
- [ ] Leafly row layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)