### PR TITLE
fix: filter Explore More to online-visible products only

### DIFF
--- a/e2e/product-detail-explore-more.spec.ts
+++ b/e2e/product-detail-explore-more.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { preVerifyAge } from './fixtures';
+
+/**
+ * Explore More — product detail related products section.
+ *
+ * Regression guard: only products with an online inventory record
+ * (availableOnline: true at locationId 'online') should appear.
+ * Products that exist in the catalog but are not online-visible must
+ * never be shown here.
+ *
+ * Relies on seed fixtures:
+ *   - blue-dream          → online, availableOnline: true  (anchor product)
+ *   - blue-dream-distillate-cart → online record exists but availableOnline: false
+ */
+test.describe('Product Detail — Explore More', () => {
+  test.beforeEach(async ({ page }) => {
+    await preVerifyAge(page);
+  });
+
+  test('only online-visible products appear in Explore More', async ({
+    page,
+  }) => {
+    await page.goto('/products/blue-dream');
+    await page.waitForSelector('.related-products', { timeout: 8000 });
+
+    const section = page.locator('.related-products');
+    await expect(section).toBeVisible();
+
+    // blue-dream-distillate-cart has availableOnline: false — must not appear
+    await expect(
+      section.locator('[href="/products/blue-dream-distillate-cart"]')
+    ).toHaveCount(0);
+  });
+
+  test('Explore More shows at least one online-available product', async ({
+    page,
+  }) => {
+    await page.goto('/products/blue-dream');
+    await page.waitForSelector('.related-products', { timeout: 8000 });
+
+    // Multiple online products exist in fixtures; at least one should render
+    const cards = page.locator('.related-strip-card');
+    await expect(cards).not.toHaveCount(0);
+  });
+});

--- a/scripts/migrate-inventory-online-config.ts
+++ b/scripts/migrate-inventory-online-config.ts
@@ -102,7 +102,9 @@ async function run(): Promise<void> {
 
   const mode = flags.apply ? 'APPLY' : 'DRY-RUN';
   console.log(`\n[inventory-online-config-migration] Mode: ${mode}`);
-  console.log(`[inventory-online-config-migration] Project: ${flags.projectId}`);
+  console.log(
+    `[inventory-online-config-migration] Project: ${flags.projectId}`
+  );
   console.log(
     `[inventory-online-config-migration] Emulator: ${process.env.FIRESTORE_EMULATOR_HOST ?? 'no'}`
   );
@@ -118,7 +120,9 @@ async function run(): Promise<void> {
     totalScanned += snap.size;
   }
 
-  console.log(`\nScanned ${totalScanned} inventory item(s) across ${locationSnap.length} location(s).`);
+  console.log(
+    `\nScanned ${totalScanned} inventory item(s) across ${locationSnap.length} location(s).`
+  );
 
   if (items.length === 0) {
     console.log('All items already have required fields. Nothing to migrate.');
@@ -164,9 +168,7 @@ async function run(): Promise<void> {
 
     await batch.commit();
     updated += chunk.length;
-    console.log(
-      `[batch] Wrote ${updated}/${items.length} item(s)...`
-    );
+    console.log(`[batch] Wrote ${updated}/${items.length} item(s)...`);
   }
 
   console.log('\nMigration summary:');

--- a/src/__tests__/lib/admin-auth.test.ts
+++ b/src/__tests__/lib/admin-auth.test.ts
@@ -66,7 +66,11 @@ describe('requireRole', () => {
   describe('given a staff session when owner role is required', () => {
     it('redirects to /admin/login (insufficient role)', async () => {
       stubSession('valid-cookie');
-      stubVerifiedToken({ uid: 'staff-uid', email: 'staff@example.com', role: 'staff' });
+      stubVerifiedToken({
+        uid: 'staff-uid',
+        email: 'staff@example.com',
+        role: 'staff',
+      });
 
       await expect(requireRole('owner')).rejects.toThrow(
         'NEXT_REDIRECT:/admin/login'

--- a/src/__tests__/lib/repositories/inventory.repository.test.ts
+++ b/src/__tests__/lib/repositories/inventory.repository.test.ts
@@ -155,13 +155,20 @@ describe('setInventoryItem — quantity: 0 clears all availability flags', () =>
         locationId: 'hub',
       });
       // No compliance check needed because nextAvailableOnline will be false
-      productGetMock.mockResolvedValue({ exists: false, data: () => undefined });
+      productGetMock.mockResolvedValue({
+        exists: false,
+        data: () => undefined,
+      });
 
       await setInventoryItem(
         'hub',
         'product-a',
         { quantity: 0 },
-        { reason: 'manual-count', updatedBy: 'admin@example.com', source: 'admin-ui' }
+        {
+          reason: 'manual-count',
+          updatedBy: 'admin@example.com',
+          source: 'admin-ui',
+        }
       );
 
       expect(batchCommitMock).toHaveBeenCalledOnce();
@@ -196,13 +203,20 @@ describe('setInventoryItem — hub: featured forced to false when availableOnlin
         featured: false,
         locationId: 'hub',
       });
-      productGetMock.mockResolvedValue({ exists: false, data: () => undefined });
+      productGetMock.mockResolvedValue({
+        exists: false,
+        data: () => undefined,
+      });
 
       await setInventoryItem(
         'hub',
         'product-b',
         { availableOnline: false, featured: true },
-        { reason: 'toggle-featured', updatedBy: 'admin@example.com', source: 'admin-ui' }
+        {
+          reason: 'toggle-featured',
+          updatedBy: 'admin@example.com',
+          source: 'admin-ui',
+        }
       );
 
       expect(batchCommitMock).toHaveBeenCalledOnce();
@@ -239,9 +253,15 @@ describe('setInventoryItem — compliance-hold blocks availableOnline / availabl
           'hub',
           'product-hold',
           { availableOnline: true },
-          { reason: 'toggle-online', updatedBy: 'admin@example.com', source: 'admin-ui' }
+          {
+            reason: 'toggle-online',
+            updatedBy: 'admin@example.com',
+            source: 'admin-ui',
+          }
         )
-      ).rejects.toThrow("Cannot mark 'product-hold' available for purchase: product is on compliance-hold");
+      ).rejects.toThrow(
+        "Cannot mark 'product-hold' available for purchase: product is on compliance-hold"
+      );
 
       expect(itemSetMock).not.toHaveBeenCalled();
       expect(batchCommitMock).not.toHaveBeenCalled();
@@ -265,7 +285,11 @@ describe('setInventoryItem — compliance-hold blocks availableOnline / availabl
           'oak-ridge',
           'product-hold',
           { availablePickup: true },
-          { reason: 'toggle-pickup', updatedBy: 'admin@example.com', source: 'admin-ui' }
+          {
+            reason: 'toggle-pickup',
+            updatedBy: 'admin@example.com',
+            source: 'admin-ui',
+          }
         )
       ).rejects.toThrow("Cannot mark 'product-hold' available for purchase");
 
@@ -292,13 +316,20 @@ describe('setInventoryItem — audit log written atomically with item update', (
         featured: false,
         locationId: 'oak-ridge',
       });
-      productGetMock.mockResolvedValue({ exists: false, data: () => undefined });
+      productGetMock.mockResolvedValue({
+        exists: false,
+        data: () => undefined,
+      });
 
       await setInventoryItem(
         'oak-ridge',
         'product-c',
         { quantity: 10 },
-        { reason: 'manual-count', updatedBy: 'admin@example.com', source: 'admin-ui' }
+        {
+          reason: 'manual-count',
+          updatedBy: 'admin@example.com',
+          source: 'admin-ui',
+        }
       );
 
       // batch.commit() must be called exactly once
@@ -318,14 +349,17 @@ describe('setInventoryItem — audit log written atomically with item update', (
       expect(logPayload.updatedBy).toBe('admin@example.com');
       expect(logPayload.reason).toBe('manual-count');
       expect(logPayload.source).toBe('admin-ui');
-      expect((logPayload.changedFields as string[])).toContain('quantity');
+      expect(logPayload.changedFields as string[]).toContain('quantity');
     });
   });
 
   describe('given a system/seed write with no adjustment parameter', () => {
     it('calls itemRef.set directly — no batch, no audit log', async () => {
       stubCurrentItem(null);
-      productGetMock.mockResolvedValue({ exists: false, data: () => undefined });
+      productGetMock.mockResolvedValue({
+        exists: false,
+        data: () => undefined,
+      });
 
       await setInventoryItem('oak-ridge', 'product-seed', {
         quantity: 5,
@@ -369,9 +403,8 @@ describe('inventory.repository — docToInventoryItem mapping', () => {
       });
 
       // getInventoryItem is a direct Firestore read — import it to verify mapping
-      const { getInventoryItem } = await import(
-        '@/lib/repositories/inventory.repository'
-      );
+      const { getInventoryItem } =
+        await import('@/lib/repositories/inventory.repository');
       const item = await getInventoryItem('oak-ridge', 'product-xyz');
 
       expect(item).not.toBeNull();
@@ -395,15 +428,14 @@ describe('inventory.repository — docToInventoryItem mapping', () => {
           locationId: 'hub',
           quantity: 0,
           inStock: false,
-          availableOnline: true,   // stored as true — must be overridden
-          availablePickup: true,   // stored as true — must be overridden
-          featured: true,          // stored as true — must be overridden
+          availableOnline: true, // stored as true — must be overridden
+          availablePickup: true, // stored as true — must be overridden
+          featured: true, // stored as true — must be overridden
         }),
       });
 
-      const { getInventoryItem } = await import(
-        '@/lib/repositories/inventory.repository'
-      );
+      const { getInventoryItem } =
+        await import('@/lib/repositories/inventory.repository');
       const item = await getInventoryItem('hub', 'product-out');
 
       expect(item!.inStock).toBe(false);

--- a/src/__tests__/lib/repositories/pending-user-invite.repository.test.ts
+++ b/src/__tests__/lib/repositories/pending-user-invite.repository.test.ts
@@ -25,13 +25,11 @@ const {
   const docMock = vi.fn((name?: string) => ({
     id: name ?? 'generated-id',
     set: setMock,
-    get: vi
-      .fn()
-      .mockResolvedValue({
-        exists: false,
-        id: name ?? 'generated-id',
-        data: () => ({}),
-      }),
+    get: vi.fn().mockResolvedValue({
+      exists: false,
+      id: name ?? 'generated-id',
+      data: () => ({}),
+    }),
   }));
 
   const collectionMock = vi.fn(() => ({

--- a/src/app/(admin)/admin/categories/[slug]/edit/CategoryEditForm.tsx
+++ b/src/app/(admin)/admin/categories/[slug]/edit/CategoryEditForm.tsx
@@ -18,8 +18,7 @@ export function CategoryEditForm({ category }: Props) {
       {state?.error && <p className="admin-error">{state.error}</p>}
 
       <label>
-        Slug{' '}
-        <span className="admin-hint">(cannot be changed)</span>
+        Slug <span className="admin-hint">(cannot be changed)</span>
         <input
           value={category.slug}
           disabled
@@ -45,7 +44,9 @@ export function CategoryEditForm({ category }: Props) {
 
       <label>
         Order{' '}
-        <span className="admin-hint">(integer \u2014 lower numbers appear first)</span>
+        <span className="admin-hint">
+          (integer — lower numbers appear first)
+        </span>
         <input
           name="order"
           type="number"

--- a/src/app/(admin)/admin/categories/new/CategoryCreateForm.tsx
+++ b/src/app/(admin)/admin/categories/new/CategoryCreateForm.tsx
@@ -16,12 +16,7 @@ export function CategoryCreateForm() {
         <span className="admin-hint">
           (unique document ID, e.g. flower \u2014 cannot be changed later)
         </span>
-        <input
-          name="slug"
-          placeholder="flower"
-          pattern="[a-z0-9-]+"
-          required
-        />
+        <input name="slug" placeholder="flower" pattern="[a-z0-9-]+" required />
       </label>
 
       <label>
@@ -36,7 +31,9 @@ export function CategoryCreateForm() {
 
       <label>
         Order{' '}
-        <span className="admin-hint">(integer \u2014 lower numbers appear first)</span>
+        <span className="admin-hint">
+          (integer — lower numbers appear first)
+        </span>
         <input name="order" type="number" min={1} step={1} required />
       </label>
 

--- a/src/app/(storefront)/products/[slug]/page.tsx
+++ b/src/app/(storefront)/products/[slug]/page.tsx
@@ -1,6 +1,10 @@
 import { notFound } from 'next/navigation';
-import { getProductBySlug, listProducts } from '@/lib/repositories';
-import { getInventoryItem } from '@/lib/repositories';
+import {
+  getProductBySlug,
+  listOnlineAvailableInventory,
+  listProductsByIds,
+  getInventoryItem,
+} from '@/lib/repositories';
 import { ONLINE_LOCATION_ID } from '@/lib/firebase/admin';
 import { getAdminStorage } from '@/lib/firebase/admin';
 import { buildMetadata } from '@/lib/seo/metadata.factory';
@@ -44,16 +48,17 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function ProductDetailPage({ params }: Props) {
   const { slug } = await params;
-  const [product, activeProducts, onlineItem] = await Promise.all([
+  const [product, onlineInventory, onlineItem] = await Promise.all([
     getProductBySlug(slug),
-    listProducts(),
+    listOnlineAvailableInventory(),
     getInventoryItem(ONLINE_LOCATION_ID, slug),
   ]);
   if (!product || product.status === 'archived') notFound();
 
-  const relatedProducts = activeProducts
-    .filter(candidate => candidate.slug !== product.slug)
-    .slice(0, 6);
+  const onlineSlugs = onlineInventory
+    .map(i => i.productId)
+    .filter(id => id !== slug);
+  const relatedProducts = (await listProductsByIds(onlineSlugs)).slice(0, 6);
 
   // Resolve hero image URL server-side to avoid client-side Firebase Storage
   // getDownloadURL round-trip, which blocks LCP by 1–3s.

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -15,7 +15,11 @@ function buildPageHref(page: number, category: string | null): string {
   return qs ? `/products?${qs}` : '/products';
 }
 
-export function Pagination({ currentPage, totalPages, category }: PaginationProps) {
+export function Pagination({
+  currentPage,
+  totalPages,
+  category,
+}: PaginationProps) {
   if (totalPages <= 1) return null;
 
   return (

--- a/src/components/ProductGridSkeleton/ProductGridSkeleton.css
+++ b/src/components/ProductGridSkeleton/ProductGridSkeleton.css
@@ -28,11 +28,21 @@
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
-.product-grid-skeleton__card:nth-child(2) { animation-delay: 0.1s; }
-.product-grid-skeleton__card:nth-child(3) { animation-delay: 0.2s; }
-.product-grid-skeleton__card:nth-child(4) { animation-delay: 0.3s; }
-.product-grid-skeleton__card:nth-child(5) { animation-delay: 0.4s; }
-.product-grid-skeleton__card:nth-child(6) { animation-delay: 0.5s; }
+.product-grid-skeleton__card:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.product-grid-skeleton__card:nth-child(3) {
+  animation-delay: 0.2s;
+}
+.product-grid-skeleton__card:nth-child(4) {
+  animation-delay: 0.3s;
+}
+.product-grid-skeleton__card:nth-child(5) {
+  animation-delay: 0.4s;
+}
+.product-grid-skeleton__card:nth-child(6) {
+  animation-delay: 0.5s;
+}
 
 /* Image placeholder — 16:9 on mobile, 5:3 on desktop (matches ProductImage.css) */
 .product-grid-skeleton__image {

--- a/src/components/ProductGridSkeleton/index.tsx
+++ b/src/components/ProductGridSkeleton/index.tsx
@@ -4,10 +4,7 @@ export function ProductGridSkeleton() {
   return (
     <div className="product-grid-skeleton" aria-hidden="true">
       {Array.from({ length: 6 }).map((_, i) => (
-        <div
-          key={i}
-          className="product-grid-skeleton__card"
-        >
+        <div key={i} className="product-grid-skeleton__card">
           <div className="product-grid-skeleton__image" />
           <div className="product-grid-skeleton__body">
             <div className="product-grid-skeleton__category" />

--- a/src/components/admin/ProductImageUpload/GalleryStrip.tsx
+++ b/src/components/admin/ProductImageUpload/GalleryStrip.tsx
@@ -36,7 +36,13 @@ interface Props {
 
 function DragHandleIcon() {
   return (
-    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 14 14"
+      fill="none"
+      aria-hidden="true"
+    >
       <circle cx="4" cy="3" r="1.5" fill="currentColor" />
       <circle cx="10" cy="3" r="1.5" fill="currentColor" />
       <circle cx="4" cy="7" r="1.5" fill="currentColor" />
@@ -188,7 +194,9 @@ function SortableImageSlot({
                 <span className="img-upload-spinner" />
               </div>
             ) : (
-              <div className="img-upload-slot-empty" aria-hidden="true">+</div>
+              <div className="img-upload-slot-empty" aria-hidden="true">
+                +
+              </div>
             )}
           </>
         )}

--- a/src/lib/repositories/location.repository.ts
+++ b/src/lib/repositories/location.repository.ts
@@ -23,19 +23,21 @@ export async function listLocations(): Promise<LocationSummary[]> {
   return snap.docs.flatMap(doc => {
     const d = doc.data();
     if (!d) return []; // doc.data() returns undefined for non-existent docs; skip phantom snapshots
-    return [{
-      id: doc.id,
-      slug: d.slug,
-      name: d.name,
-      address: d.address,
-      city: d.city,
-      state: d.state,
-      zip: d.zip,
-      phone: d.phone,
-      hours: d.hours,
-      placeId: d.placeId,
-      coordinates: d.coordinates ?? undefined,
-    } satisfies LocationSummary];
+    return [
+      {
+        id: doc.id,
+        slug: d.slug,
+        name: d.name,
+        address: d.address,
+        city: d.city,
+        state: d.state,
+        zip: d.zip,
+        phone: d.phone,
+        hours: d.hours,
+        placeId: d.placeId,
+        coordinates: d.coordinates ?? undefined,
+      } satisfies LocationSummary,
+    ];
   });
 }
 


### PR DESCRIPTION
## Summary
- `listProducts()` on the product detail page returned all active products, leaking in-store-only items into the "Explore More" section
- Switched to `listOnlineAvailableInventory()` + `listProductsByIds()` — identical pattern used by the products listing page
- Only products with an online inventory record (`availableOnline: true`) now appear in the related products strip

## Test plan
- [ ] New E2E spec `product-detail-explore-more.spec.ts` asserts `blue-dream-distillate-cart` (availableOnline: false) never appears in Explore More
- [ ] Second test asserts at least one valid online product renders in the section
- [ ] All 634 unit tests passing locally
- [ ] Lint, typecheck, and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)