### PR TITLE
chore: untrack node_modules from git index

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/kb/Developer/rush-n-relax/node_modules


### PR DESCRIPTION
`node_modules` was accidentally tracked by git. This removes it from the index without deleting the actual directory.

`.gitignore` already has `node_modules/` — this commit makes it take effect.