### PR TITLE
chore: tighten firestore rules for launch

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -42,13 +42,23 @@ service cloud.firestore {
     match /promos/{docId} {
       allow read, write: if false;
     }
-    // inventory/online — storefront reads allowed for pricing resolution.
-    // All other locations and all writes remain server-only.
-    match /inventory/online/items/{productId} {
-      allow read: if true;
-      allow write: if false;
-    }
+    // Inventory: Admin SDK only — all storefront reads go through Server Components.
     match /inventory/{locationId}/items/{productId} {
+      allow read, write: if false;
+    }
+
+    // Orders: Admin SDK only (customer PII + payment references)
+    match /orders/{orderId} {
+      allow read, write: if false;
+    }
+
+    // Vendors: Admin SDK only
+    match /vendors/{docId} {
+      allow read, write: if false;
+    }
+
+    // Pending user invites: Admin SDK only
+    match /pending-user-invites/{email} {
       allow read, write: if false;
     }
 

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -21,6 +21,8 @@
   --admin-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
   --admin-shadow-soft: 0 10px 24px rgba(0, 0, 0, 0.25);
   --admin-radius: 14px;
+  --admin-back-link-margin-bottom: 0.75rem;
+  --admin-back-link-font-size: 0.875rem;
   --admin-heading-color: #f6ecd6;
   --admin-nav-link-padding: 0.3rem 0.8rem;
   --admin-nav-link-focus-border: rgba(213, 179, 106, 0.32);
@@ -2379,9 +2381,9 @@
 /* ── Admin back-link ─────────────────────────────────────────────────────── */
 .admin-back-link {
   display: inline-block;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--admin-back-link-margin-bottom);
   color: var(--admin-accent);
-  font-size: 0.875rem;
+  font-size: var(--admin-back-link-font-size);
   font-weight: 600;
   text-decoration: none;
   transition: color 0.2s ease;


### PR DESCRIPTION
## Summary
- Add explicit deny for orders, vendors, pending-user-invites (defense in depth)
- Remove dead public read on inventory/online/items (no client code reads it)

## Kept
- location-reviews public read — used by useLocationReviews on location pages

## Bundled fix
- Extract admin-back-link spacing to CSS vars (same fix as PR #191/#192; duplicated here so this branch can land independently)

## Test plan
- [ ] Playwright E2E still passes (storefront product + location pages render)
- [ ] Emulator test: client read of orders/* returns permission-denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)