### PR TITLE
perf: replace force-dynamic with ISR revalidate on storefront pages

### DIFF
--- a/src/app/(storefront)/products/page.tsx
+++ b/src/app/(storefront)/products/page.tsx
@@ -6,7 +6,7 @@ import { listActiveCategories } from '@/lib/repositories';
 import { ProductsGrid } from './ProductsGrid';
 import '@/styles/products.css';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 300; // 5 minutes — catalog changes infrequently
 
 export const metadata = buildMetadata('/products', {
   title:


### PR DESCRIPTION
Closes #167

## Summary
- Products page switched from `force-dynamic` to `revalidate = 300` (5 min ISR), enabling Vercel CDN caching
- Catalog updates a few times per day at most; 5-minute staleness is acceptable
- Expected result: second request to `/products` returns `x-vercel-cache: HIT`

## Audit of other storefront pages
| Page | Status |
|---|---|
| `/vendors` | already `revalidate = 3600` — no change |
| `/locations` | already `revalidate = 86400` — no change |
| `/order/[id]` | kept `force-dynamic` — personalised, real-time order status polling |
| `/admin/**` | unchanged — auth-gated, must always serve fresh data |

## Test plan
- [ ] Lint + typecheck pass locally
- [ ] Vercel preview: load `/products` twice, verify second response has `x-vercel-cache: HIT`
- [ ] Confirm category filter + pagination still work against the cached page

---
Generated by BrewCortex worker agent