### PR TITLE
fix: show inline toast when inventory cascade silently blocks availability

### DIFF
--- a/src/__tests__/app/admin/inventory/actions.test.ts
+++ b/src/__tests__/app/admin/inventory/actions.test.ts
@@ -2,12 +2,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
 
-const { requireRoleMock, setInventoryItemMock, revalidatePathMock } =
-  vi.hoisted(() => ({
-    requireRoleMock: vi.fn(),
-    setInventoryItemMock: vi.fn().mockResolvedValue(undefined),
-    revalidatePathMock: vi.fn(),
-  }));
+const {
+  requireRoleMock,
+  setInventoryItemMock,
+  getInventoryItemMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  requireRoleMock: vi.fn(),
+  setInventoryItemMock: vi.fn().mockResolvedValue(undefined),
+  getInventoryItemMock: vi.fn().mockResolvedValue(null),
+  revalidatePathMock: vi.fn(),
+}));
 
 vi.mock('@/lib/admin-auth', () => ({
   requireRole: requireRoleMock,
@@ -15,6 +20,7 @@ vi.mock('@/lib/admin-auth', () => ({
 
 vi.mock('@/lib/repositories', () => ({
   setInventoryItem: setInventoryItemMock,
+  getInventoryItem: getInventoryItemMock,
 }));
 
 vi.mock('next/cache', () => ({
@@ -40,11 +46,30 @@ function stubUnauthorised() {
   });
 }
 
+function stubSavedItem(overrides: {
+  availableOnline?: boolean;
+  availablePickup?: boolean;
+  inStock?: boolean;
+  quantity?: number;
+}) {
+  getInventoryItemMock.mockResolvedValue({
+    productId: 'p',
+    locationId: 'hub',
+    inStock: overrides.inStock ?? false,
+    availableOnline: overrides.availableOnline ?? false,
+    availablePickup: overrides.availablePickup ?? false,
+    featured: false,
+    quantity: overrides.quantity ?? 0,
+  });
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('updateInventoryItem server action', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setInventoryItemMock.mockResolvedValue(undefined);
+    getInventoryItemMock.mockResolvedValue(null);
   });
 
   describe('given an unauthenticated caller', () => {
@@ -179,6 +204,75 @@ describe('updateInventoryItem server action', () => {
       ).rejects.toThrow('compliance-hold');
 
       expect(revalidatePathMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Cascade-blocked signal (issue #179) ──────────────────────────────────
+
+  describe('given availableOnline was requested true but quantity is 0', () => {
+    it('returns blocked.availableOnline so the UI can toast', async () => {
+      stubAuthorisedActor();
+      stubSavedItem({
+        availableOnline: false,
+        availablePickup: false,
+        inStock: false,
+        quantity: 0,
+      });
+
+      const result = await updateInventoryItem('hub', 'product-g', {
+        availableOnline: true,
+      });
+
+      expect(result).toEqual({ blocked: { availableOnline: true } });
+    });
+  });
+
+  describe('given availablePickup was requested true but quantity is 0', () => {
+    it('returns blocked.availablePickup so the UI can toast', async () => {
+      stubAuthorisedActor();
+      stubSavedItem({
+        availableOnline: false,
+        availablePickup: false,
+        inStock: false,
+        quantity: 0,
+      });
+
+      const result = await updateInventoryItem('oak-ridge', 'product-h', {
+        availablePickup: true,
+      });
+
+      expect(result).toEqual({ blocked: { availablePickup: true } });
+    });
+  });
+
+  describe('given availability was requested and the cascade allowed it', () => {
+    it('returns an empty result (no blocked flags)', async () => {
+      stubAuthorisedActor();
+      stubSavedItem({
+        availableOnline: true,
+        availablePickup: true,
+        inStock: true,
+        quantity: 5,
+      });
+
+      const result = await updateInventoryItem('hub', 'product-i', {
+        availableOnline: true,
+      });
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('given the patch does not request enabling availability', () => {
+    it('does not re-read the item and returns an empty result', async () => {
+      stubAuthorisedActor();
+
+      const result = await updateInventoryItem('hub', 'product-j', {
+        quantity: 10,
+      });
+
+      expect(getInventoryItemMock).not.toHaveBeenCalled();
+      expect(result).toEqual({});
     });
   });
 });

--- a/src/app/(admin)/admin/inventory/[locationId]/InventoryTable.tsx
+++ b/src/app/(admin)/admin/inventory/[locationId]/InventoryTable.tsx
@@ -81,6 +81,7 @@ function InventoryRow({
   const [availablePickup, setAvailablePickup] = useState(row.availablePickup);
   const [featured, setFeatured] = useState(row.featured);
   const [updateError, setUpdateError] = useState<string | null>(null);
+  const [blockedMessage, setBlockedMessage] = useState<string | null>(null);
   const [showSuccess, setShowSuccess] = useState(false);
   const [showPricing, setShowPricing] = useState(false);
 
@@ -148,9 +149,26 @@ function InventoryRow({
 
     startTransition(async () => {
       try {
-        await updateInventoryItem(locationId, row.id, nextPatch);
+        const result = await updateInventoryItem(
+          locationId,
+          row.id,
+          nextPatch
+        );
         setUpdateError(null);
-        triggerSuccess();
+        if (result.blocked?.availableOnline || result.blocked?.availablePickup) {
+          // Cascade enforcement: quantity=0 silently forces availability false.
+          // Surface an inline toast so staff understand why the toggle didn't stick.
+          // Do NOT auto-restore the flags — the server is the source of truth.
+          setBlockedMessage(
+            'Set quantity above 0 to re-enable online/pickup availability.'
+          );
+          setAvailableOnline(false);
+          setAvailablePickup(false);
+          setTimeout(() => setBlockedMessage(null), 4000);
+        } else {
+          setBlockedMessage(null);
+          triggerSuccess();
+        }
         router.refresh();
       } catch {
         setQuantityInput(previous.quantityInput);
@@ -240,6 +258,15 @@ function InventoryRow({
             />
             {updateError && (
               <span className="admin-inline-error">{updateError}</span>
+            )}
+            {blockedMessage && (
+              <span
+                className="admin-inline-toast"
+                role="status"
+                aria-live="polite"
+              >
+                {blockedMessage}
+              </span>
             )}
             <span
               className={

--- a/src/app/(admin)/admin/inventory/[locationId]/actions.ts
+++ b/src/app/(admin)/admin/inventory/[locationId]/actions.ts
@@ -2,8 +2,24 @@
 
 import { revalidatePath } from 'next/cache';
 import { requireRole } from '@/lib/admin-auth';
-import { setInventoryItem } from '@/lib/repositories';
+import { getInventoryItem, setInventoryItem } from '@/lib/repositories';
 import type { InventoryItem } from '@/types/inventory';
+
+/**
+ * Result returned by {@link updateInventoryItem}.
+ *
+ * `blocked` describes availability flags that the caller asked to enable
+ * but which the inventory cascade silently forced to `false` (e.g. because
+ * quantity is 0 → inStock=false → availableOnline/availablePickup=false).
+ * Consumers should surface an inline toast when any blocked flag is set;
+ * the underlying patch is NOT auto-restored.
+ */
+export interface UpdateInventoryItemResult {
+  blocked?: {
+    availableOnline?: true;
+    availablePickup?: true;
+  };
+}
 
 export async function updateInventoryItem(
   locationId: string,
@@ -15,7 +31,7 @@ export async function updateInventoryItem(
     availablePickup?: boolean;
     featured?: boolean;
   }
-): Promise<void> {
+): Promise<UpdateInventoryItemResult> {
   const actor = await requireRole('owner');
 
   const reason =
@@ -50,10 +66,34 @@ export async function updateInventoryItem(
     }
   );
 
+  // Detect invariant cascade: if the caller tried to enable an availability
+  // flag, re-read the item and see whether the cascade forced it back to false.
+  const result: UpdateInventoryItemResult = {};
+  const wantsAvailableOnline = patch.availableOnline === true;
+  const wantsAvailablePickup = patch.availablePickup === true;
+
+  if (wantsAvailableOnline || wantsAvailablePickup) {
+    const saved = await getInventoryItem(locationId, productId);
+    if (saved) {
+      const blocked: UpdateInventoryItemResult['blocked'] = {};
+      if (wantsAvailableOnline && saved.availableOnline === false) {
+        blocked.availableOnline = true;
+      }
+      if (wantsAvailablePickup && saved.availablePickup === false) {
+        blocked.availablePickup = true;
+      }
+      if (blocked.availableOnline || blocked.availablePickup) {
+        result.blocked = blocked;
+      }
+    }
+  }
+
   revalidatePath(`/admin/inventory/${locationId}`);
   revalidatePath('/admin/inventory');
   revalidatePath('/');
   revalidatePath('/products');
+
+  return result;
 }
 
 export async function updateVariantPricing(

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1339,6 +1339,16 @@
   font-size: 0.8rem;
 }
 
+.admin-inline-toast {
+  color: var(--admin-warn-text, #92400e);
+  background: var(--admin-warn-bg, #fef3c7);
+  border: 1px solid var(--admin-warn-border, #fcd34d);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  margin-left: 0.5rem;
+}
+
 .admin-input--inline {
   flex: 0 1 140px;
   min-width: 80px;


### PR DESCRIPTION
Closes #179

## Summary
When staff set quantity to 0, `setInventoryItem` silently cascades `availableOnline` and `availablePickup` to false via invariant enforcement. Previously there was no UI feedback, causing staff confusion at open (design handoff Finding #5).

## Changes
- `updateInventoryItem` server action now returns `{ blocked?: { availableOnline?: true; availablePickup?: true } }`. When the caller requested enabling an availability flag, we re-read the saved item and flag any that the cascade forced back to false.
- `InventoryTable` consumes the result. On a blocked response it shows an inline aria-live toast:
  > Set quantity above 0 to re-enable online/pickup availability.
- Toggles are NOT auto-restored — the server is the source of truth.
- Added `.admin-inline-toast` style in `src/styles/admin.css` (amber warn palette).

## Tests
- 4 new cases in `actions.test.ts`:
  - `availableOnline=true` + qty 0 → `blocked.availableOnline`
  - `availablePickup=true` + qty 0 → `blocked.availablePickup`
  - cascade allowed → empty result
  - non-availability patch → no re-read, empty result
- Full suite: 654/654 passing
- `tsc --noEmit` clean

## Acceptance criteria
- [x] Toast appears when qty=0 and staff attempts to enable online or pickup availability
- [x] Toast text clearly explains the cause
- [x] No auto-restore of flags
- [x] Existing inventory tests pass

Pre-launch — addresses staff confusion at open.