### PR TITLE
perf: wrap repo point-reads with React cache()

### DIFF
--- a/src/lib/repositories/inventory.repository.ts
+++ b/src/lib/repositories/inventory.repository.ts
@@ -18,6 +18,7 @@
  *   - featured = false when inStock = false (online location only)
  *   - Every mutation writes an immutable adjustment record
  */
+import { cache } from 'react';
 import {
   getAdminFirestore,
   toDate,
@@ -70,16 +71,19 @@ export async function listInventoryForLocation(
  * Fetch a single inventory item for a product at a location.
  * Returns null if the item has not been tracked yet.
  * Callers should treat null as { inStock: false, availableOnline: false }.
+ * Wrapped with React cache() to deduplicate parallel calls within the same request.
  */
-export async function getInventoryItem(
-  locationId: string,
-  productId: string
-): Promise<InventoryItem | null> {
-  const doc = await inventoryItemsCol(locationId).doc(productId).get();
-  if (!doc.exists) return null;
-  // doc.data() is safe here: existence is confirmed on the line above
-  return docToInventoryItem(doc.id, doc.data()!);
-}
+export const getInventoryItem = cache(
+  async (
+    locationId: string,
+    productId: string
+  ): Promise<InventoryItem | null> => {
+    const doc = await inventoryItemsCol(locationId).doc(productId).get();
+    if (!doc.exists) return null;
+    // doc.data() is safe here: existence is confirmed on the line above
+    return docToInventoryItem(doc.id, doc.data()!);
+  }
+);
 
 /**
  * Return the subset of the given product ids that are both online and in stock.

--- a/src/lib/repositories/product.repository.ts
+++ b/src/lib/repositories/product.repository.ts
@@ -2,6 +2,7 @@
  * Product repository — all Firestore access for product documents.
  * Server-side only (uses firebase-admin).
  */
+import { cache } from 'react';
 import { getAdminFirestore, toDate } from '@/lib/firebase/admin';
 import type {
   Product,
@@ -41,9 +42,7 @@ export async function listAllProducts(
   opts: { limit?: number; cursor?: string } = {}
 ): Promise<PageResult<ProductSummary>> {
   const limit = opts.limit ?? 50;
-  let query = productsCol()
-    .orderBy('name')
-    .limit(limit);
+  let query = productsCol().orderBy('name').limit(limit);
 
   const afterSnap = await resolveCursor(opts.cursor);
   if (afterSnap) query = query.startAfter(afterSnap);
@@ -154,14 +153,18 @@ export async function listProductsByCategory(
 /**
  * Fetch a single product by slug.
  * Returns null if not found.
+ * Wrapped with React cache() to deduplicate parallel calls within the same
+ * request (e.g. generateMetadata + page component both reading the same slug).
  */
-export async function getProductBySlug(slug: string): Promise<Product | null> {
-  const doc = await productsCol().doc(slug).get();
-  if (!doc.exists) return null;
-  const data = doc.data();
-  if (!data) return null;
-  return docToProduct(doc.id, data);
-}
+export const getProductBySlug = cache(
+  async (slug: string): Promise<Product | null> => {
+    const doc = await productsCol().doc(slug).get();
+    if (!doc.exists) return null;
+    const data = doc.data();
+    if (!data) return null;
+    return docToProduct(doc.id, data);
+  }
+);
 
 /**
  * List active products for a given vendor slug.

--- a/src/lib/repositories/promo.repository.ts
+++ b/src/lib/repositories/promo.repository.ts
@@ -2,6 +2,7 @@
  * Promo repository — all Firestore access for promotion documents.
  * Server-side only (uses firebase-admin).
  */
+import { cache } from 'react';
 import { getAdminFirestore, toDate } from '@/lib/firebase/admin';
 import type { Promo, PromoSummary } from '@/types';
 import type { PageResult } from './types';
@@ -32,9 +33,7 @@ export async function listAllPromos(
   opts: { limit?: number; cursor?: string } = {}
 ): Promise<PageResult<PromoSummary>> {
   const limit = opts.limit ?? 50;
-  let query = promosCol()
-    .orderBy('name')
-    .limit(limit);
+  let query = promosCol().orderBy('name').limit(limit);
 
   const afterSnap = await resolveCursor(opts.cursor);
   if (afterSnap) query = query.startAfter(afterSnap);
@@ -100,13 +99,17 @@ export async function listActivePromos(
 /**
  * Fetch a single promo by slug.
  * Returns null if not found.
+ * Wrapped with React cache() to deduplicate parallel calls within the same
+ * request (e.g. generateMetadata + page component both reading the same slug).
  */
-export async function getPromoBySlug(slug: string): Promise<Promo | null> {
-  const doc = await promosCol().doc(slug).get();
-  if (!doc.exists) return null;
-  // doc.data() is safe here: existence is confirmed on the line above
-  return docToPromo(doc.id, doc.data()!);
-}
+export const getPromoBySlug = cache(
+  async (slug: string): Promise<Promo | null> => {
+    const doc = await promosCol().doc(slug).get();
+    if (!doc.exists) return null;
+    // doc.data() is safe here: existence is confirmed on the line above
+    return docToPromo(doc.id, doc.data()!);
+  }
+);
 
 /**
  * Fetch promos for a specific location slug.

--- a/src/lib/repositories/vendor.repository.ts
+++ b/src/lib/repositories/vendor.repository.ts
@@ -2,6 +2,7 @@
  * Vendor repository — all Firestore access for vendor documents.
  * Server-side only (uses firebase-admin).
  */
+import { cache } from 'react';
 import { FieldValue } from 'firebase-admin/firestore';
 import { getAdminFirestore, toDate } from '@/lib/firebase/admin';
 import type { Vendor, VendorSummary } from '@/types';
@@ -57,9 +58,7 @@ export async function listAllVendors(
   opts: { limit?: number; cursor?: string } = {}
 ): Promise<PageResult<VendorSummary>> {
   const limit = opts.limit ?? 50;
-  let query = vendorsCol()
-    .orderBy('name')
-    .limit(limit);
+  let query = vendorsCol().orderBy('name').limit(limit);
 
   const afterSnap = await resolveCursor(opts.cursor);
   if (afterSnap) query = query.startAfter(afterSnap);
@@ -75,14 +74,18 @@ export async function listAllVendors(
 /**
  * Fetch a single vendor by slug.
  * Returns null if not found.
+ * Wrapped with React cache() to deduplicate parallel calls within the same
+ * request (e.g. generateMetadata + page component both reading the same slug).
  */
-export async function getVendorBySlug(slug: string): Promise<Vendor | null> {
-  const doc = await vendorsCol().doc(slug).get();
-  if (!doc.exists) return null;
-  const data = doc.data();
-  if (!data) return null;
-  return docToVendor(doc.id, data);
-}
+export const getVendorBySlug = cache(
+  async (slug: string): Promise<Vendor | null> => {
+    const doc = await vendorsCol().doc(slug).get();
+    if (!doc.exists) return null;
+    const data = doc.data();
+    if (!data) return null;
+    return docToVendor(doc.id, data);
+  }
+);
 
 // ── Write operations ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #166

## Summary
Wrap high-traffic repository point-read functions with React `cache()` to deduplicate parallel calls within a single server render (e.g. `generateMetadata` + the page component both reading the same slug = 1 Firestore read instead of 2).

## Changes
- `product.repository.ts` → `getProductBySlug` wrapped
- `vendor.repository.ts` → `getVendorBySlug` wrapped
- `promo.repository.ts` → `getPromoBySlug` wrapped
- `inventory.repository.ts` → `getInventoryItem` wrapped
- `location.repository.ts` → `getLocationBySlug` (already wrapped — confirmed, comment already present)

## Verification
- `products/[slug]/page.tsx` calls `getProductBySlug(slug)` in both `generateMetadata` (line 38) and the page body (line 52) — these now share one Firestore read per request.
- Typecheck clean.
- All 100 repository Vitest tests pass (cache is request-scoped and transparent to unit tests).
- Lint: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)