### PR TITLE
feat: add Cache-Control headers to API routes

### DIFF
--- a/src/app/api/auth/session/route.test.ts
+++ b/src/app/api/auth/session/route.test.ts
@@ -187,6 +187,51 @@ describe('auth session route', () => {
     expect(createSessionCookieMock).not.toHaveBeenCalled();
   });
 
+  it('sets Cache-Control: no-store on successful session creation (POST 200)', async () => {
+    verifyIdTokenMock.mockResolvedValue({
+      uid: 'owner-uid',
+      email: 'owner@rushnrelax.com',
+      role: 'owner',
+    });
+    createSessionCookieMock.mockResolvedValue('session-cookie-value');
+
+    const response = await POST(createPostRequest('valid-token'));
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('sets Cache-Control: no-store on 403 rejection (POST)', async () => {
+    verifyIdTokenMock.mockResolvedValue({
+      uid: 'customer-uid',
+      email: 'customer@example.com',
+      role: 'customer',
+    });
+
+    const response = await POST(createPostRequest('customer-token'));
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('sets Cache-Control: no-store on 400 bad body (POST)', async () => {
+    const req = new Request('http://localhost/api/auth/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(req);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('sets Cache-Control: no-store on DELETE', () => {
+    const response = DELETE();
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
   it('clears the session cookie on delete', () => {
     const response = DELETE();
     const cookie = response.headers.get('Set-Cookie') ?? '';

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -12,6 +12,13 @@ const SESSION_MAX_AGE_S = 60 * 60 * 24 * 5; // 5 days in seconds
 const OWNER_ROLE: UserRole = 'owner';
 const CLAIMS_UPDATED_RETRY_CODE = 'CLAIMS_UPDATED_RETRY';
 
+// Auth session requests must never be cached by browsers or CDNs.
+const NO_STORE: HeadersInit = { 'Cache-Control': 'no-store' };
+
+function jsonNoStore(body: unknown, status: number): Response {
+  return Response.json(body, { status, headers: NO_STORE });
+}
+
 function getRoleClaim(payload: unknown): unknown {
   if (typeof payload !== 'object' || payload === null) {
     return undefined;
@@ -50,6 +57,9 @@ function parseOwnerAllowlist(): Set<string> {
  *
  * Session cookie is issued only when the user holds a recognized, non-customer role.
  * Gate: isUserRole(roleClaim) && roleClaim !== 'customer'
+ *
+ * Cache-Control: no-store on every response — session issuance must not be
+ * cached by browsers or intermediaries.
  */
 export async function POST(request: Request): Promise<Response> {
   let idToken: string;
@@ -58,17 +68,17 @@ export async function POST(request: Request): Promise<Response> {
     const body: unknown = await request.json();
 
     if (typeof body !== 'object' || body === null) {
-      return Response.json({ error: 'idToken required' }, { status: 400 });
+      return jsonNoStore({ error: 'idToken required' }, 400);
     }
 
     const tokenValue = (body as { idToken?: unknown }).idToken;
     if (typeof tokenValue !== 'string' || tokenValue.length === 0) {
-      return Response.json({ error: 'idToken required' }, { status: 400 });
+      return jsonNoStore({ error: 'idToken required' }, 400);
     }
 
     idToken = tokenValue;
   } catch {
-    return Response.json({ error: 'Invalid request body' }, { status: 400 });
+    return jsonNoStore({ error: 'Invalid request body' }, 400);
   }
 
   try {
@@ -90,12 +100,12 @@ export async function POST(request: Request): Promise<Response> {
           role: OWNER_ROLE,
         });
 
-        return Response.json(
+        return jsonNoStore(
           {
             error: 'Owner claim applied. Refreshing token required.',
             code: CLAIMS_UPDATED_RETRY_CODE,
           },
-          { status: 409 }
+          409
         );
       }
     }
@@ -122,18 +132,18 @@ export async function POST(request: Request): Promise<Response> {
             acceptedByUid: decoded.uid,
           });
 
-          return Response.json(
+          return jsonNoStore(
             {
               error: 'Invite role applied. Refreshing token required.',
               code: CLAIMS_UPDATED_RETRY_CODE,
             },
-            { status: 409 }
+            409
           );
         }
       }
 
       // No valid staff-or-above role and no pending invite — reject.
-      return Response.json({ error: 'Forbidden' }, { status: 403 });
+      return jsonNoStore({ error: 'Forbidden' }, 403);
     }
 
     const sessionCookie = await adminAuth.createSessionCookie(idToken, {
@@ -153,20 +163,22 @@ export async function POST(request: Request): Promise<Response> {
 
     return new Response(null, {
       status: 200,
-      headers: { 'Set-Cookie': cookieHeader },
+      headers: {
+        'Set-Cookie': cookieHeader,
+        'Cache-Control': 'no-store',
+      },
     });
   } catch (err) {
     console.error('[auth/session] createSessionCookie failed:', err);
-    return Response.json(
-      { error: 'Failed to create session' },
-      { status: 401 }
-    );
+    return jsonNoStore({ error: 'Failed to create session' }, 401);
   }
 }
 
 /**
  * DELETE /api/auth/session
  * Clear the session cookie (logout).
+ *
+ * Cache-Control: no-store — logout must never be cached.
  */
 export function DELETE(): Response {
   const cookieHeader = [
@@ -181,6 +193,9 @@ export function DELETE(): Response {
     .join('; ');
   return new Response(null, {
     status: 200,
-    headers: { 'Set-Cookie': cookieHeader },
+    headers: {
+      'Set-Cookie': cookieHeader,
+      'Cache-Control': 'no-store',
+    },
   });
 }

--- a/src/app/api/order/[id]/status/route.test.ts
+++ b/src/app/api/order/[id]/status/route.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getOrderMock } = vi.hoisted(() => ({
+  getOrderMock: vi.fn(),
+}));
+
+vi.mock('@/lib/repositories', () => ({
+  getOrder: getOrderMock,
+}));
+
+import { GET } from './route';
+
+function createRequest(): Request {
+  return new Request('http://localhost/api/order/abc/status');
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/order/[id]/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with status and Cache-Control: private, max-age=10', async () => {
+    getOrderMock.mockResolvedValue({ id: 'abc', status: 'preparing' });
+
+    const res = await GET(createRequest(), makeParams('abc'));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('private, max-age=10');
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('preparing');
+  });
+
+  it('returns 404 with Cache-Control header when order is missing', async () => {
+    getOrderMock.mockResolvedValue(null);
+
+    const res = await GET(createRequest(), makeParams('missing'));
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get('Cache-Control')).toBe('private, max-age=10');
+  });
+});

--- a/src/app/api/order/[id]/status/route.ts
+++ b/src/app/api/order/[id]/status/route.ts
@@ -5,10 +5,15 @@ interface Params {
   params: Promise<{ id: string }>;
 }
 
+const CACHE_CONTROL = 'private, max-age=10';
+
 /**
  * GET /api/order/[id]/status
  * Lightweight status check used by the client polling island.
  * Returns { status } only — no internal fields exposed.
+ *
+ * Cache-Control: private, max-age=10 — lets the browser dedupe rapid polls
+ * while keeping the response user-scoped (never shared by a CDN).
  */
 export async function GET(
   _request: Request,
@@ -17,7 +22,13 @@ export async function GET(
   const { id } = await params;
   const order = await getOrder(id);
   if (!order) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json(
+      { error: 'Not found' },
+      { status: 404, headers: { 'Cache-Control': CACHE_CONTROL } }
+    );
   }
-  return NextResponse.json({ status: order.status });
+  return NextResponse.json(
+    { status: order.status },
+    { headers: { 'Cache-Control': CACHE_CONTROL } }
+  );
 }


### PR DESCRIPTION
Closes #165

## Summary

Adds explicit `Cache-Control` headers to API routes that previously shipped without any, so browsers and Vercel's edge can dedupe requests appropriately.

| Route | Header |
|-------|--------|
| `GET /api/order/[id]/status` | `private, max-age=10` |
| `POST /api/auth/session` | `no-store` (all status codes: 200/400/401/403/409) |
| `DELETE /api/auth/session` | `no-store` |
| `GET /api/cart/availability` | `private, max-age=30` (already set in #164 — untouched) |

## What changed

- `src/app/api/order/[id]/status/route.ts` — extracted `CACHE_CONTROL` constant, attached to both 200 and 404 responses.
- `src/app/api/auth/session/route.ts` — introduced a `jsonNoStore(body, status)` helper so every error/409 response carries `Cache-Control: no-store`; 200 Set-Cookie response also sets it alongside the cookie header.
- Added `src/app/api/order/[id]/status/route.test.ts` (new) with BDD-style assertions for header + status on hit/miss.
- Extended `src/app/api/auth/session/route.test.ts` with four header-assertion cases (POST 200, POST 403, POST 400, DELETE).

## Test plan

- [x] `npx vitest run` on both route test files → 14/14 passing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] Manual `curl -I` verification once merged to a preview deploy

Generated with Claude Code