### PR TITLE
fix: send contact emails from verified root domain to rush+kb

### DIFF
--- a/docs/launch-runbook.md
+++ b/docs/launch-runbook.md
@@ -19,6 +19,7 @@ Operating procedure for taking rushnrelax.com live. Follow in order. Do not skip
 - [ ] Legal pages live: `/terms`, `/privacy`, `/shipping`
 - [ ] AgeChecker dashboard: `rushnrelax.com` domain added, webhook URL set, test mode OFF
 - [ ] Clover sandbox keys received and swapped in (assumes Monday delivery)
+- [ ] **Resend API key rotated to new RnR account** — generate key, `firebase functions:secrets:set RESEND_API_KEY`, verify sender domain (SPF/DKIM in Cloudflare), redeploy functions, revoke personal-account key after smoke test confirms `outbound-emails/{jobId}` → `status: sent`
 
 ### Final env var audit
 

--- a/src/lib/repositories/contact.repository.ts
+++ b/src/lib/repositories/contact.repository.ts
@@ -196,10 +196,8 @@ export async function submitContactAndQueueEmail(
     templateId: renderedEmail.templateId ?? 'contact-submission-default',
     subject: renderedEmail.subject,
     html: renderedEmail.html,
-    from:
-      process.env.CONTACT_EMAIL_FROM ??
-      'Rush N Relax <no-reply@support.rushnrelax.com>',
-    to: [process.env.CONTACT_EMAIL_TO ?? 'support@rushnrelax.com'],
+    from: 'Rush N Relax <no-reply@rushnrelax.com>',
+    to: ['rush@rushnrelax.com', 'kb@rushnrelax.com'],
     payload,
     attemptCount: 0,
     maxAttempts: 5,
@@ -248,9 +246,7 @@ export async function queueTestContactEmail(params: {
     templateId: renderedEmail.templateId,
     subject: renderedEmail.subject,
     html: renderedEmail.html,
-    from:
-      process.env.CONTACT_EMAIL_FROM ??
-      'Rush N Relax <no-reply@support.rushnrelax.com>',
+    from: 'Rush N Relax <no-reply@rushnrelax.com>',
     to: [params.to],
     payload,
   });


### PR DESCRIPTION
## Summary
- Switches contact-submission `from` from `no-reply@support.rushnrelax.com` (unverified subdomain on the new Resend account) to `no-reply@rushnrelax.com` (verified root, DKIM + SPF live)
- Moves recipients from the non-existent `support@rushnrelax.com` mailbox to `rush@rushnrelax.com` + `kb@rushnrelax.com`
- Drops unused `CONTACT_EMAIL_FROM` / `CONTACT_EMAIL_TO` env fallbacks
- Pins the Resend key rotation + DNS verification steps into the launch runbook

## Why now
Blocking launch. All historical contact-submission jobs were stuck in `queued` status because the previous sender subdomain was never verified on the new RnR Resend account and the target mailbox doesn't exist.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `vitest run contact.repository.test.ts` — 3 passed
- [ ] After merge + Vercel deploy, submit a test contact form → verify new `outbound-emails/{jobId}` transitions to `status: sent` and `rush@` + `kb@` receive the email
- [ ] Requeue the two historical stuck jobs via `/admin/email-queue` once above passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)