### PR TITLE
feat(admin): inline toast on inventory qty=0 cascade

### DIFF
--- a/apps/web/src/__tests__/app/admin/inventory/InventoryTable.test.tsx
+++ b/apps/web/src/__tests__/app/admin/inventory/InventoryTable.test.tsx
@@ -153,3 +153,73 @@ describe('InventoryTable — qty=0 cascade toast (issue #198)', () => {
     });
   });
 });
+
+describe('InventoryTable — toast dismissal (issue #220)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateInventoryItemMock.mockResolvedValue({});
+  });
+
+  describe('given the cascade toast is showing', () => {
+    it('auto-dismisses after 5 seconds', async () => {
+      vi.useFakeTimers();
+      try {
+        render(
+          <InventoryTable
+            rows={[baseRow({ availableOnline: true })]}
+            locationId="hub"
+            isOnline
+          />
+        );
+        const qty = screen.getByLabelText(/Quantity for Test Flower/i);
+        await act(async () => {
+          fireEvent.change(qty, { target: { value: '0' } });
+          fireEvent.blur(qty);
+        });
+        // Flush the awaited action
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(screen.getByText(TOAST_COPY)).toBeInTheDocument();
+
+        // Just before 5s, still there
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(4999);
+        });
+        expect(screen.queryByText(TOAST_COPY)).toBeInTheDocument();
+
+        // At 5s, gone
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2);
+        });
+        expect(screen.queryByText(TOAST_COPY)).not.toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('dismisses immediately when staff begins re-editing the row', async () => {
+      render(
+        <InventoryTable
+          rows={[baseRow({ availableOnline: true })]}
+          locationId="hub"
+          isOnline
+        />
+      );
+      const qty = screen.getByLabelText(/Quantity for Test Flower/i);
+      await act(async () => {
+        fireEvent.change(qty, { target: { value: '0' } });
+        fireEvent.blur(qty);
+      });
+      await waitFor(() => {
+        expect(screen.getByText(TOAST_COPY)).toBeInTheDocument();
+      });
+
+      // Re-edit the qty input — toast should clear immediately
+      await act(async () => {
+        fireEvent.change(qty, { target: { value: '3' } });
+      });
+      expect(screen.queryByText(TOAST_COPY)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/(admin)/admin/inventory/[locationId]/InventoryTable.tsx
+++ b/apps/web/src/app/(admin)/admin/inventory/[locationId]/InventoryTable.tsx
@@ -114,6 +114,7 @@ function InventoryRow({
     value: boolean
   ) {
     clearError();
+    if (blockedMessage) setBlockedMessage(null);
     const inStockCascaded = field === 'inStock' && !value;
 
     const nextPatch: {
@@ -178,12 +179,12 @@ function InventoryRow({
             availablePickup: false,
           });
           setBlockedMessage(QTY_ZERO_TOAST);
-          setTimeout(() => setBlockedMessage(null), 4000);
+          setTimeout(() => setBlockedMessage(null), 5000);
         } else if (inStockCascaded) {
           // inStock toggled off -> qty forced to 0, availability cleared.
           // Surface inline toast so staff understand the cascade.
           setBlockedMessage(QTY_ZERO_TOAST);
-          setTimeout(() => setBlockedMessage(null), 4000);
+          setTimeout(() => setBlockedMessage(null), 5000);
         } else {
           setBlockedMessage(null);
           triggerSuccess();
@@ -195,6 +196,8 @@ function InventoryRow({
 
   function handleQuantityInput(value: string) {
     if (/^\d*$/.test(value)) {
+      // Dismiss any lingering cascade toast when staff begins re-editing the row.
+      if (blockedMessage) setBlockedMessage(null);
       const nextQty = normalizeQuantityInput(value);
       setState({
         quantityInput: value,
@@ -232,7 +235,7 @@ function InventoryRow({
       onSuccess: () => {
         if (cascadeCleared) {
           setBlockedMessage(QTY_ZERO_TOAST);
-          setTimeout(() => setBlockedMessage(null), 4000);
+          setTimeout(() => setBlockedMessage(null), 5000);
         } else {
           triggerSuccess();
         }


### PR DESCRIPTION
Closes #220

## What
Tightens the qty=0 cascade toast in the admin inventory table to match the acceptance spec:

- Toast auto-dismiss bumped from 4s to 5s
- Toast now dismisses immediately when staff begins re-editing the row (qty input change or toggle click)
- Row-scoped (rendered inside the toggle cell, not global)
- Flags remain off after qty goes back above 0 — no auto-restore (server is source of truth)

## Tests
- 6 unit tests passing in `InventoryTable.test.tsx` including new coverage for:
  - 5s auto-dismiss timing
  - Dismiss-on-re-edit behavior
- Typecheck + lint clean

## Agent
Worked by: worker agent (inline)