### PR TITLE
refactor(inventory): retire availableOnline in types + repository

### DIFF
--- a/apps/web/src/__tests__/lib/repositories/inventory.repository.test.ts
+++ b/apps/web/src/__tests__/lib/repositories/inventory.repository.test.ts
@@ -79,6 +79,7 @@ vi.mock('@/lib/firebase/admin', () => ({
   toDate: (value: Date | string | undefined) =>
     value ? new Date(value) : new Date(0),
   HUB_LOCATION_ID: 'hub',
+  ONLINE_LOCATION_ID: 'online',
 }));
 
 import { setInventoryItem } from '@/lib/repositories/inventory.repository';
@@ -111,7 +112,7 @@ describe('inventory.repository — normalizeQuantity invariants', () => {
   describe('given quantity: -5 on a new item', () => {
     it('clamps to 0 and sets inStock = false', async () => {
       stubCurrentItem(null);
-      stubProduct(null); // no compliance check needed (online=false)
+      stubProduct(null);
 
       await setInventoryItem('oak-ridge', 'product-a', { quantity: -5 });
 
@@ -137,31 +138,68 @@ describe('inventory.repository — normalizeQuantity invariants', () => {
   });
 });
 
-// ── setInventoryItem — zero-quantity invariants ───────────────────────────
+// ── setInventoryItem — availableOnline retirement (#232) ──────────────────
 
-describe('setInventoryItem — quantity: 0 clears all availability flags', () => {
+describe('setInventoryItem — availableOnline is no longer persisted', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('given an item currently in stock with all flags true', () => {
-    it('when quantity is set to 0, inStock / availableOnline / availablePickup / featured all become false', async () => {
+  describe('given an item with availableOnline: true requested', () => {
+    it('omits availableOnline from the written item payload', async () => {
+      stubCurrentItem({
+        quantity: 5,
+        inStock: true,
+        availablePickup: false,
+        featured: false,
+        locationId: 'online',
+      });
+      stubProduct(null); // no compliance status → no throw
+
+      await setInventoryItem(
+        'online',
+        'product-a',
+        { availableOnline: true },
+        {
+          reason: 'toggle-online',
+          updatedBy: 'admin@example.com',
+          source: 'admin-ui',
+        }
+      );
+
+      expect(batchCommitMock).toHaveBeenCalledOnce();
+      const [, itemPayload] = batchSetMock.mock.calls[0] as [
+        unknown,
+        Record<string, unknown>,
+      ];
+      expect(itemPayload).not.toHaveProperty('availableOnline');
+    });
+  });
+});
+
+// ── setInventoryItem — zero-quantity invariants ───────────────────────────
+
+describe('setInventoryItem — quantity: 0 clears availability flags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('given an item currently in stock with flags true', () => {
+    it('when quantity is set to 0, inStock / availablePickup / featured all become false', async () => {
       stubCurrentItem({
         quantity: 10,
         inStock: true,
-        availableOnline: true,
         availablePickup: true,
         featured: true,
-        locationId: 'hub',
+        locationId: 'online',
       });
-      // No compliance check needed because nextAvailableOnline will be false
       productGetMock.mockResolvedValue({
         exists: false,
         data: () => undefined,
       });
 
       await setInventoryItem(
-        'hub',
+        'online',
         'product-a',
         { quantity: 0 },
         {
@@ -172,36 +210,33 @@ describe('setInventoryItem — quantity: 0 clears all availability flags', () =>
       );
 
       expect(batchCommitMock).toHaveBeenCalledOnce();
-      // First batchSet call is the item; second is the adjustment log
       const [, itemPayload] = batchSetMock.mock.calls[0] as [
         unknown,
         Record<string, unknown>,
       ];
       expect(itemPayload.quantity).toBe(0);
       expect(itemPayload.inStock).toBe(false);
-      expect(itemPayload.availableOnline).toBe(false);
       expect(itemPayload.availablePickup).toBe(false);
       expect(itemPayload.featured).toBe(false);
     });
   });
 });
 
-// ── setInventoryItem — hub featured invariant ─────────────────────────────
+// ── setInventoryItem — featured requires inStock (all locations) ──────────
 
-describe('setInventoryItem — hub: featured forced to false when availableOnline is false', () => {
+describe('setInventoryItem — featured requires inStock at every location', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('given hub location with availableOnline: false and featured: true requested', () => {
-    it('persists featured = false', async () => {
+  describe('given an online-store item inStock with featured: true requested', () => {
+    it('persists featured = true (availableOnline is no longer a precondition)', async () => {
       stubCurrentItem({
         quantity: 5,
         inStock: true,
-        availableOnline: false,
         availablePickup: false,
         featured: false,
-        locationId: 'hub',
+        locationId: 'online',
       });
       productGetMock.mockResolvedValue({
         exists: false,
@@ -209,9 +244,9 @@ describe('setInventoryItem — hub: featured forced to false when availableOnlin
       });
 
       await setInventoryItem(
-        'hub',
+        'online',
         'product-b',
-        { availableOnline: false, featured: true },
+        { featured: true },
         {
           reason: 'toggle-featured',
           updatedBy: 'admin@example.com',
@@ -224,7 +259,7 @@ describe('setInventoryItem — hub: featured forced to false when availableOnlin
         unknown,
         Record<string, unknown>,
       ];
-      expect(itemPayload.featured).toBe(false);
+      expect(itemPayload.featured).toBe(true);
     });
   });
 });
@@ -237,20 +272,19 @@ describe('setInventoryItem — compliance-hold blocks availableOnline / availabl
   });
 
   describe('given a product on compliance-hold when availableOnline: true is requested', () => {
-    it('throws without writing any document', async () => {
+    it('throws without writing any document (legacy intent still gated)', async () => {
       stubCurrentItem({
         quantity: 5,
         inStock: true,
-        availableOnline: false,
         availablePickup: false,
         featured: false,
-        locationId: 'hub',
+        locationId: 'online',
       });
       stubProduct('compliance-hold');
 
       await expect(
         setInventoryItem(
-          'hub',
+          'online',
           'product-hold',
           { availableOnline: true },
           {
@@ -273,7 +307,6 @@ describe('setInventoryItem — compliance-hold blocks availableOnline / availabl
       stubCurrentItem({
         quantity: 5,
         inStock: true,
-        availableOnline: false,
         availablePickup: false,
         featured: false,
         locationId: 'oak-ridge',
@@ -311,7 +344,6 @@ describe('setInventoryItem — audit log written atomically with item update', (
       stubCurrentItem({
         quantity: 3,
         inStock: true,
-        availableOnline: false,
         availablePickup: false,
         featured: false,
         locationId: 'oak-ridge',
@@ -332,13 +364,9 @@ describe('setInventoryItem — audit log written atomically with item update', (
         }
       );
 
-      // batch.commit() must be called exactly once
       expect(batchCommitMock).toHaveBeenCalledOnce();
-
-      // Two batch.set() calls: item payload + audit log entry
       expect(batchSetMock).toHaveBeenCalledTimes(2);
 
-      // The second batch.set() is the audit log entry
       const [, logPayload] = batchSetMock.mock.calls[1] as [
         unknown,
         Record<string, unknown>,
@@ -350,6 +378,12 @@ describe('setInventoryItem — audit log written atomically with item update', (
       expect(logPayload.reason).toBe('manual-count');
       expect(logPayload.source).toBe('admin-ui');
       expect(logPayload.changedFields as string[]).toContain('quantity');
+      // availableOnline is retired — always false in audit log
+      expect(logPayload.previousAvailableOnline).toBe(false);
+      expect(logPayload.nextAvailableOnline).toBe(false);
+      expect(logPayload.changedFields as string[]).not.toContain(
+        'availableOnline'
+      );
     });
   });
 
@@ -372,9 +406,7 @@ describe('setInventoryItem — audit log written atomically with item update', (
   });
 });
 
-// ── docToInventoryItem mapping (tested indirectly through setInventoryItem +
-//    listInventoryForLocation, but we verify the key field mappings here via
-//    a stub of listInventoryForLocation's underlying .get() call) ──────────
+// ── docToInventoryItem mapping ────────────────────────────────────────────
 
 describe('inventory.repository — docToInventoryItem mapping', () => {
   beforeEach(() => {
@@ -383,9 +415,6 @@ describe('inventory.repository — docToInventoryItem mapping', () => {
 
   describe('given a Firestore doc with all fields present', () => {
     it('maps productId from doc.id, not d.productId', async () => {
-      // We exercise the mapping by reading back via getInventoryItem path.
-      // The snapshot must carry `id` because docToInventoryItem(doc.id, doc.data())
-      // reads the document id from the snapshot object itself.
       itemGetMock.mockResolvedValue({
         id: 'product-xyz',
         exists: true,
@@ -393,7 +422,6 @@ describe('inventory.repository — docToInventoryItem mapping', () => {
           locationId: 'oak-ridge',
           quantity: 7,
           inStock: true,
-          availableOnline: false,
           availablePickup: true,
           featured: true,
           notes: 'low stock',
@@ -402,9 +430,9 @@ describe('inventory.repository — docToInventoryItem mapping', () => {
         }),
       });
 
-      // getInventoryItem is a direct Firestore read — import it to verify mapping
-      const { getInventoryItem } =
-        await import('@/lib/repositories/inventory.repository');
+      const { getInventoryItem } = await import(
+        '@/lib/repositories/inventory.repository'
+      );
       const item = await getInventoryItem('oak-ridge', 'product-xyz');
 
       expect(item).not.toBeNull();
@@ -416,30 +444,31 @@ describe('inventory.repository — docToInventoryItem mapping', () => {
       expect(item!.featured).toBe(true);
       expect(item!.notes).toBe('low stock');
       expect(item!.updatedBy).toBe('admin@rushnrelax.com');
+      // availableOnline is no longer read/returned by the mapper
+      expect(item!.availableOnline).toBeUndefined();
     });
   });
 
   describe('given a Firestore doc with inStock: false', () => {
-    it('forces availableOnline, availablePickup, and featured to false regardless of stored values', async () => {
+    it('forces availablePickup and featured to false regardless of stored values', async () => {
       itemGetMock.mockResolvedValue({
         id: 'product-out',
         exists: true,
         data: () => ({
-          locationId: 'hub',
+          locationId: 'online',
           quantity: 0,
           inStock: false,
-          availableOnline: true, // stored as true — must be overridden
-          availablePickup: true, // stored as true — must be overridden
-          featured: true, // stored as true — must be overridden
+          availablePickup: true,
+          featured: true,
         }),
       });
 
-      const { getInventoryItem } =
-        await import('@/lib/repositories/inventory.repository');
-      const item = await getInventoryItem('hub', 'product-out');
+      const { getInventoryItem } = await import(
+        '@/lib/repositories/inventory.repository'
+      );
+      const item = await getInventoryItem('online', 'product-out');
 
       expect(item!.inStock).toBe(false);
-      expect(item!.availableOnline).toBe(false);
       expect(item!.availablePickup).toBe(false);
       expect(item!.featured).toBe(false);
     });

--- a/apps/web/src/lib/repositories/inventory.repository.ts
+++ b/apps/web/src/lib/repositories/inventory.repository.ts
@@ -13,16 +13,20 @@
  * Invariants (enforced at every write):
  *   - quantity ≥ 0, integer
  *   - inStock = quantity > 0
- *   - availableOnline = false when inStock = false
  *   - availablePickup = false when inStock = false
- *   - featured = false when inStock = false (online location only)
+ *   - featured = false when inStock = false
  *   - Every mutation writes an immutable adjustment record
+ *
+ * Legacy `availableOnline` was retired in #232 — the repository no longer
+ * reads or writes that field. Compliance guards continue to honor an
+ * `availableOnline: true` patch argument for back-compat with admin actions
+ * pending their own removal (#233); the request is treated as intent to
+ * expose the product for purchase.
  */
 import { cache } from 'react';
 import {
   getAdminFirestore,
   toDate,
-  HUB_LOCATION_ID,
   ONLINE_LOCATION_ID,
 } from '@/lib/firebase/admin';
 import type {
@@ -70,7 +74,7 @@ export async function listInventoryForLocation(
 /**
  * Fetch a single inventory item for a product at a location.
  * Returns null if the item has not been tracked yet.
- * Callers should treat null as { inStock: false, availableOnline: false }.
+ * Callers should treat null as { inStock: false }.
  * Wrapped with React cache() to deduplicate parallel calls within the same request.
  */
 export const getInventoryItem = cache(
@@ -130,7 +134,6 @@ export async function listOnlineAvailableInventory(
       productId: doc.id,
       locationId: ONLINE_LOCATION_ID,
       inStock: d.inStock ?? false,
-      availableOnline: d.availableOnline ?? false,
       availablePickup: false,
       featured: d.featured ?? false,
       quantity: d.quantity ?? undefined,
@@ -146,11 +149,11 @@ export async function listOnlineAvailableInventory(
 /**
  * List featured inventory items for a location.
  *
- * Hub: returns items where featured = true. Invariants guarantee availableOnline
- * and inStock are also true. Used to populate homepage "What We Carry".
+ * Online: returns items where featured = true. Invariants guarantee inStock
+ * is also true. Used to populate homepage "What We Carry".
  *
- * Retail: returns items where featured = true. Invariants guarantee inStock is
- * also true. Used to populate per-store featured sections.
+ * Retail: returns items where featured = true. Invariants guarantee inStock
+ * is also true. Used to populate per-store featured sections.
  */
 export async function listFeaturedInventory(
   locationId: string,
@@ -175,7 +178,6 @@ export async function listFeaturedInventory(
       productId: doc.id,
       locationId,
       inStock: d.inStock ?? false,
-      availableOnline: d.availableOnline ?? false,
       availablePickup: d.availablePickup ?? false,
       featured: true,
       quantity: d.quantity ?? undefined,
@@ -188,14 +190,37 @@ export async function listFeaturedInventory(
   };
 }
 
+/**
+ * List featured inventory items at a location, returning the full
+ * `InventoryItem` shape (not the summary). Filters to featured && inStock —
+ * the invariant at write-time guarantees featured implies inStock, but the
+ * equality query is spelled out here to keep the contract explicit.
+ *
+ * Introduced for the simplified storefront/home-page rails (#238) that need
+ * the full item (notes, updatedAt, etc.) without a second round-trip.
+ */
+export async function listFeaturedAtLocation(
+  locationId: string
+): Promise<InventoryItem[]> {
+  const col = inventoryItemsCol(locationId);
+  const snap = await col
+    .where('featured', '==', true)
+    .where('inStock', '==', true)
+    .get();
+  return snap.docs.map(doc => docToInventoryItem(doc.id, doc.data()));
+}
+
 // ── Write operations ──────────────────────────────────────────────────────
 
 /**
  * Create or update an inventory item.
  * Document ID is the productId — one record per product per location.
  *
- * Compliance guard: setting availableOnline: true is blocked if the product
- * has status 'compliance-hold'. Throws if violated.
+ * Compliance guard: setting availableOnline: true (legacy, back-compat) or
+ * availablePickup: true is blocked if the product has status 'compliance-hold'.
+ * Throws if violated. Note that `availableOnline` is no longer persisted —
+ * the argument is honored only as intent for the compliance check until
+ * consumer call sites are cleaned up (#233).
  *
  * Every call writes an immutable adjustment log entry atomically alongside
  * the item update. The `adjustment` parameter controls the log metadata.
@@ -207,6 +232,7 @@ export async function setInventoryItem(
   productId: string,
   patch: {
     inStock?: boolean;
+    /** @deprecated Legacy — accepted for compliance-guard back-compat only; not persisted. */
     availableOnline?: boolean;
     availablePickup?: boolean;
     featured?: boolean;
@@ -227,14 +253,12 @@ export async function setInventoryItem(
   const itemRef = inventoryItemsCol(locationId).doc(productId);
   const currentSnap = await itemRef.get();
   const current = currentSnap.data();
-  const isHub = locationId === HUB_LOCATION_ID;
 
   const currentQuantity = normalizeQuantity(
     current?.quantity,
     current?.inStock ?? false
   );
   const currentInStock: boolean = current?.inStock ?? false;
-  const currentAvailableOnline: boolean = current?.availableOnline ?? false;
   const currentAvailablePickup: boolean = current?.availablePickup ?? false;
   const currentFeatured: boolean = current?.featured ?? false;
 
@@ -249,22 +273,22 @@ export async function setInventoryItem(
 
   const nextInStock = nextQuantity > 0;
 
-  const requestedAvailableOnline =
-    patch.availableOnline ?? currentAvailableOnline;
   const requestedAvailablePickup =
     patch.availablePickup ?? currentAvailablePickup;
   const requestedFeatured = patch.featured ?? currentFeatured;
 
-  const nextAvailableOnline = nextInStock ? requestedAvailableOnline : false;
   const nextAvailablePickup = nextInStock ? requestedAvailablePickup : false;
-  // Hub: featured requires availableOnline; all locations: featured requires inStock
-  const nextFeatured = isHub
-    ? nextAvailableOnline && requestedFeatured
-    : nextInStock && requestedFeatured;
+  // featured requires inStock at every location; availableOnline is no longer
+  // a precondition (storefront visibility derives from inStock at the online
+  // location directly — see listFeaturedAtLocation).
+  const nextFeatured = nextInStock && requestedFeatured;
 
-  if (nextAvailableOnline || nextAvailablePickup) {
+  // Compliance guard: still honors the legacy availableOnline === true intent
+  // so admin actions that haven't been migrated (#233) keep their safety net.
+  const requestsOnlineIntent = patch.availableOnline === true && nextInStock;
+  if (requestsOnlineIntent || nextAvailablePickup) {
     // Intentional cross-collection read: this compliance guard must be
-    // co‑located with the write to avoid a circular dependency between repos.
+    // co-located with the write to avoid a circular dependency between repos.
     const productDoc = await db.collection('products').doc(productId).get();
     if (productDoc.exists && productDoc.data()?.status === 'compliance-hold') {
       throw new Error(
@@ -282,7 +306,6 @@ export async function setInventoryItem(
     locationId,
     quantity: nextQuantity,
     inStock: nextInStock,
-    availableOnline: nextAvailableOnline,
     availablePickup: nextAvailablePickup,
     featured: nextFeatured,
     ...(patch.notes !== undefined && { notes: patch.notes }),
@@ -298,8 +321,6 @@ export async function setInventoryItem(
     const changedFields: InventoryAdjustment['changedFields'] = [];
     if (nextQuantity !== currentQuantity) changedFields.push('quantity');
     if (nextInStock !== currentInStock) changedFields.push('inStock');
-    if (nextAvailableOnline !== currentAvailableOnline)
-      changedFields.push('availableOnline');
     if (nextAvailablePickup !== currentAvailablePickup)
       changedFields.push('availablePickup');
     if (nextFeatured !== currentFeatured) changedFields.push('featured');
@@ -325,8 +346,9 @@ export async function setInventoryItem(
       deltaQuantity: nextQuantity - currentQuantity,
       previousInStock: currentInStock,
       nextInStock,
-      previousAvailableOnline: currentAvailableOnline,
-      nextAvailableOnline,
+      // Legacy schema fields — always false since availableOnline is retired (#232).
+      previousAvailableOnline: false,
+      nextAvailableOnline: false,
       previousAvailablePickup: currentAvailablePickup,
       nextAvailablePickup,
       previousFeatured: currentFeatured,
@@ -353,15 +375,13 @@ function docToInventoryItem(
 ): InventoryItem {
   const quantity = normalizeQuantity(d.quantity, d.inStock ?? false);
   const inStock = quantity > 0;
-  const availableOnline = inStock ? (d.availableOnline ?? false) : false;
 
   return {
     productId: id,
     locationId: d.locationId,
     inStock,
-    availableOnline,
     availablePickup: inStock ? (d.availablePickup ?? false) : false,
-    // featured requires inStock; for hub it also requires availableOnline
+    // featured requires inStock at every location.
     featured: inStock ? (d.featured ?? false) : false,
     quantity,
     variantPricing: docToVariantPricing(d.variantPricing),

--- a/apps/web/src/types/inventory.ts
+++ b/apps/web/src/types/inventory.ts
@@ -3,7 +3,10 @@
  * Lives at: inventory/{locationId}/items/{productId}
  *
  * locationId can be a retail location slug or HUB_LOCATION_ID ('hub').
- * Online Store items support availableOnline to promote stock to the storefront.
+ *
+ * Storefront visibility is now derived from `inStock` at the online location
+ * (see location-ids.ts — ONLINE_LOCATION_ID). The legacy `availableOnline`
+ * flag has been retired; the persisted field was dropped by migration #231.
  */
 export interface InventoryItem {
   /** References products/{productId} */
@@ -13,10 +16,13 @@ export interface InventoryItem {
   /** Whether this product is currently in stock at this location */
   inStock: boolean;
   /**
-   * Online Store only — when true, product is listed for online purchase.
-   * Always false for retail locations.
+   * @deprecated Retired in #232 — no longer persisted or read by the
+   * repository. Remains as an optional field so pending consumer code
+   * (admin UI, server actions, fixtures) continues to compile until their
+   * own removal tickets land (#233 actions, #234 UI). New code MUST NOT
+   * rely on this field.
    */
-  availableOnline: boolean;
+  availableOnline?: boolean;
   /**
    * Retail locations only — when true, product can be purchased online for
    * in-store pickup at this location. Deducts from this location's inventory.
@@ -25,9 +31,9 @@ export interface InventoryItem {
   availablePickup: boolean;
   /**
    * When true, product is spotlighted at this location.
-   * Online Store: shown in homepage "What We Carry" (requires availableOnline = true).
+   * Online Store: shown in homepage "What We Carry" (requires inStock = true).
    * Retail: shown in per-store featured section (requires inStock = true).
-   * Always false when inStock = false; Online Store also clears when availableOnline = false.
+   * Always false when inStock = false.
    */
   featured: boolean;
   /** Optional unit count — for future staff-facing stock level display */
@@ -78,6 +84,10 @@ export type InventoryAdjustmentSource = 'admin-ui' | 'system' | 'api';
 /**
  * Immutable audit record for a single inventory mutation.
  * Lives at: inventory/{locationId}/items/{productId}/adjustments/{adjustmentId}
+ *
+ * `availableOnline` tracking fields are retained for schema backward-compat
+ * with historic adjustment documents. New records always write `false` for
+ * previous/next availableOnline (the field is no longer mutated — see #232).
  */
 export interface InventoryAdjustment {
   productId: string;
@@ -99,7 +109,9 @@ export interface InventoryAdjustment {
   deltaQuantity: number;
   previousInStock: boolean;
   nextInStock: boolean;
+  /** @deprecated Always false — `availableOnline` is no longer persisted. */
   previousAvailableOnline: boolean;
+  /** @deprecated Always false — `availableOnline` is no longer persisted. */
   nextAvailableOnline: boolean;
   previousAvailablePickup: boolean;
   nextAvailablePickup: boolean;


### PR DESCRIPTION
Closes #232

## What
Retires the `availableOnline` field from the inventory type + repository, now that migration #231 has landed (#241) and the persisted field is gone from Firestore.

## Approach — (a) Optional + deprecated, not hard-removed

Per dispatch guidance: kept `availableOnline?: boolean` as an optional/deprecated field on `InventoryItem` (and `InventoryItemSummary`) so consumer code still compiling against it (admin actions, UI, fixtures) keeps working until their own removal tickets land:

- #233 — `actions.ts` cleanup
- #234 — `InventoryTable.tsx` / admin page cleanup
- #237 — `firestore.rules` cleanup

This keeps the blast radius of this PR tight (types + repo + repo tests only) while achieving the core goal: the repository no longer writes or reads `availableOnline` to/from Firestore. The fixture shape (`InventoryItemFixture`) in `lib/fixtures/storefront.ts` is out of scope and left as-is.

## Changes
- `apps/web/src/types/inventory.ts`
  - `InventoryItem.availableOnline` -> optional + `@deprecated`
  - `InventoryAdjustment.{previousAvailableOnline,nextAvailableOnline}` -> marked deprecated (always `false` going forward; kept on the schema for historic adjustment docs)
  - Updated doc comments: featured requires only `inStock` at every location
- `apps/web/src/lib/repositories/inventory.repository.ts`
  - `setInventoryItem` no longer writes `availableOnline` to the item payload
  - `docToInventoryItem` no longer reads/returns it
  - `listOnlineAvailableInventory` / `listFeaturedInventory` drop `availableOnline` from the summary mapping
  - Adjustment log always writes `previousAvailableOnline: false, nextAvailableOnline: false`
  - Compliance guard still honors `patch.availableOnline === true` as an intent signal (back-compat for #233-pending admin actions)
  - Hub-specific "featured requires availableOnline" invariant removed — uniform rule now: featured requires inStock at every location
  - New: `listFeaturedAtLocation(locationId: string): Promise<InventoryItem[]>` — filters `featured && inStock`, returns full items (for #238)
- `apps/web/src/__tests__/lib/repositories/inventory.repository.test.ts`
  - Updated assertions; added "availableOnline not persisted even when requested"

## Acceptance
- [x] `pnpm typecheck` clean
- [x] All 684 unit tests pass (70 files)
- [x] `listFeaturedAtLocation` helper added
- [ ] `grep -r 'availableOnline' apps/web/src` returns zero matches — not met; see "Approach" above. Full grep-zero will be achieved after #233 / #234 / #237 land.

## Notes for review
- Compliance-hold guard intentionally still reacts to `patch.availableOnline === true`. Once #233 lands, that branch can be deleted in a follow-up.
- `HUB_LOCATION_ID` import dropped from the repo (no longer used after removing the hub-only featured branch).

---
Generated by BrewCortex worker agent