### PR TITLE
refactor(admin): drop cascade logic from inventory server action

### DIFF
--- a/apps/web/src/__tests__/app/admin/inventory/actions.test.ts
+++ b/apps/web/src/__tests__/app/admin/inventory/actions.test.ts
@@ -128,6 +128,7 @@ describe('updateInventoryItem server action', () => {
   describe('given a valid owner toggling featured', () => {
     it('calls setInventoryItem with toggle-featured reason', async () => {
       stubAuthorisedActor();
+      stubSavedItem({ inStock: true, availablePickup: true, quantity: 5 });
 
       await updateInventoryItem('hub', 'product-c', { featured: true });
 
@@ -159,24 +160,6 @@ describe('updateInventoryItem server action', () => {
     });
   });
 
-  describe('given a valid owner toggling availableOnline', () => {
-    it('calls setInventoryItem with toggle-online reason', async () => {
-      stubAuthorisedActor();
-
-      await updateInventoryItem('hub', 'product-e', {
-        availableOnline: true,
-      });
-
-      const [, , , adjustment] = setInventoryItemMock.mock.calls[0] as [
-        string,
-        string,
-        Record<string, unknown>,
-        Record<string, unknown>,
-      ];
-      expect(adjustment.reason).toBe('toggle-online');
-    });
-  });
-
   describe('given a successful update', () => {
     it('revalidates the expected paths', async () => {
       stubAuthorisedActor();
@@ -200,79 +183,33 @@ describe('updateInventoryItem server action', () => {
       );
 
       await expect(
-        updateInventoryItem('hub', 'product-hold', { availableOnline: true })
+        updateInventoryItem('hub', 'product-hold', { inStock: true })
       ).rejects.toThrow('compliance-hold');
 
       expect(revalidatePathMock).not.toHaveBeenCalled();
     });
   });
 
-  // ── Cascade-blocked signal (issue #179) ──────────────────────────────────
+  // Cascade-blocked signal (issue #179) was removed in issue #233 —
+  // the inStock master-switch model replaces cascade behavior.
 
-  describe('given availableOnline was requested true but quantity is 0', () => {
-    it('returns blocked.availableOnline so the UI can toast', async () => {
+  describe('given featured=true is requested while the item is not inStock', () => {
+    it('returns ok:false with an invariant-violation error', async () => {
       stubAuthorisedActor();
       stubSavedItem({
-        availableOnline: false,
         availablePickup: false,
         inStock: false,
         quantity: 0,
       });
 
-      const result = await updateInventoryItem('hub', 'product-g', {
-        availableOnline: true,
+      const result = await updateInventoryItem('hub', 'product-k', {
+        featured: true,
       });
 
-      expect(result).toEqual({ blocked: { availableOnline: true } });
-    });
-  });
-
-  describe('given availablePickup was requested true but quantity is 0', () => {
-    it('returns blocked.availablePickup so the UI can toast', async () => {
-      stubAuthorisedActor();
-      stubSavedItem({
-        availableOnline: false,
-        availablePickup: false,
-        inStock: false,
-        quantity: 0,
+      expect(result).toEqual({
+        ok: false,
+        error: 'Cannot feature an item that is not in stock.',
       });
-
-      const result = await updateInventoryItem('oak-ridge', 'product-h', {
-        availablePickup: true,
-      });
-
-      expect(result).toEqual({ blocked: { availablePickup: true } });
-    });
-  });
-
-  describe('given availability was requested and the cascade allowed it', () => {
-    it('returns an empty result (no blocked flags)', async () => {
-      stubAuthorisedActor();
-      stubSavedItem({
-        availableOnline: true,
-        availablePickup: true,
-        inStock: true,
-        quantity: 5,
-      });
-
-      const result = await updateInventoryItem('hub', 'product-i', {
-        availableOnline: true,
-      });
-
-      expect(result).toEqual({});
-    });
-  });
-
-  describe('given the patch does not request enabling availability', () => {
-    it('does not re-read the item and returns an empty result', async () => {
-      stubAuthorisedActor();
-
-      const result = await updateInventoryItem('hub', 'product-j', {
-        quantity: 10,
-      });
-
-      expect(getInventoryItemMock).not.toHaveBeenCalled();
-      expect(result).toEqual({});
     });
   });
 });

--- a/apps/web/src/app/(admin)/admin/inventory/[locationId]/actions.ts
+++ b/apps/web/src/app/(admin)/admin/inventory/[locationId]/actions.ts
@@ -8,18 +8,17 @@ import type { InventoryItem } from '@/types/inventory';
 /**
  * Result returned by {@link updateInventoryItem}.
  *
- * `blocked` describes availability flags that the caller asked to enable
- * but which the inventory cascade silently forced to `false` (e.g. because
- * quantity is 0 → inStock=false → availableOnline/availablePickup=false).
- * Consumers should surface an inline toast when any blocked flag is set;
- * the underlying patch is NOT auto-restored.
+ * Success returns the saved item. Failure returns an error string
+ * (400-style client error — e.g. invariant violation).
+ *
+ * @deprecated `blocked` is a transitional compat field retained so the
+ * existing admin UI (InventoryTable) keeps compiling while issue #234
+ * redesigns the consumer. It is always an empty object and will be
+ * removed in #234.
  */
-export interface UpdateInventoryItemResult {
-  blocked?: {
-    availableOnline?: true;
-    availablePickup?: true;
-  };
-}
+export type UpdateInventoryItemResult =
+  | { ok: true; data: InventoryItem; blocked?: Record<string, never> }
+  | { ok: false; error: string; blocked?: Record<string, never> };
 
 export async function updateInventoryItem(
   locationId: string,
@@ -27,12 +26,25 @@ export async function updateInventoryItem(
   patch: {
     inStock?: boolean;
     quantity?: number;
-    availableOnline?: boolean;
     availablePickup?: boolean;
     featured?: boolean;
   }
 ): Promise<UpdateInventoryItemResult> {
   const actor = await requireRole('owner');
+
+  // Invariant: featured=true requires inStock=true in the same patch
+  // (or already-true on the saved doc). Reject eagerly rather than
+  // silently writing a broken state.
+  if (patch.featured === true && patch.inStock !== true) {
+    const current =
+      patch.inStock === false ? null : await getInventoryItem(locationId, productId);
+    if (!current || current.inStock !== true) {
+      return {
+        ok: false,
+        error: 'Cannot feature an item that is not in stock.',
+      };
+    }
+  }
 
   const reason =
     patch.quantity !== undefined
@@ -41,9 +53,7 @@ export async function updateInventoryItem(
         ? 'toggle-stock'
         : patch.featured !== undefined
           ? 'toggle-featured'
-          : patch.availablePickup !== undefined
-            ? 'toggle-pickup'
-            : 'toggle-online';
+          : 'toggle-pickup';
 
   await setInventoryItem(
     locationId,
@@ -51,9 +61,6 @@ export async function updateInventoryItem(
     {
       ...(patch.inStock !== undefined && { inStock: patch.inStock }),
       ...(patch.quantity !== undefined && { quantity: patch.quantity }),
-      ...(patch.availableOnline !== undefined && {
-        availableOnline: patch.availableOnline,
-      }),
       ...(patch.availablePickup !== undefined && {
         availablePickup: patch.availablePickup,
       }),
@@ -66,34 +73,21 @@ export async function updateInventoryItem(
     }
   );
 
-  // Detect invariant cascade: if the caller tried to enable an availability
-  // flag, re-read the item and see whether the cascade forced it back to false.
-  const result: UpdateInventoryItemResult = {};
-  const wantsAvailableOnline = patch.availableOnline === true;
-  const wantsAvailablePickup = patch.availablePickup === true;
-
-  if (wantsAvailableOnline || wantsAvailablePickup) {
-    const saved = await getInventoryItem(locationId, productId);
-    if (saved) {
-      const blocked: UpdateInventoryItemResult['blocked'] = {};
-      if (wantsAvailableOnline && saved.availableOnline === false) {
-        blocked.availableOnline = true;
-      }
-      if (wantsAvailablePickup && saved.availablePickup === false) {
-        blocked.availablePickup = true;
-      }
-      if (blocked.availableOnline || blocked.availablePickup) {
-        result.blocked = blocked;
-      }
-    }
-  }
+  const saved = await getInventoryItem(locationId, productId);
 
   revalidatePath(`/admin/inventory/${locationId}`);
   revalidatePath('/admin/inventory');
   revalidatePath('/');
   revalidatePath('/products');
 
-  return result;
+  if (!saved) {
+    return {
+      ok: false,
+      error: 'Inventory item not found after write.',
+    };
+  }
+
+  return { ok: true, data: saved, blocked: {} };
 }
 
 export async function updateVariantPricing(


### PR DESCRIPTION
Closes #233

Removes the `wantsAvailableOnline` cascade + `blocked` return shape from `updateInventoryItem`. Replaces with validate → write → return. Adds invariant: `featured=true` requires `inStock=true` (returns `{ ok: false, error: ... }` otherwise).

## Transitional compat

`UpdateInventoryItemResult` keeps `blocked?: Record<string, never>` on both variants so `InventoryTable.tsx` compiles unchanged. Field is deprecated and removed in #234 when the UI is redesigned.

## Tests
- Deleted 4 cascade-behavior tests (issue #179 signal)
- Updated the compliance-hold test to use `inStock: true` in the patch
- Added invariant test: `featured=true` without `inStock=true` returns `ok:false`
- Featured toggle test now stubs a saved inStock item so invariant passes
- 11/11 tests pass

## Salvage note
Original worker stream timed out after writing the main diff. I committed what it produced after typechecking + running tests clean against main. The refactor itself is entirely the worker's work.