### PR TITLE
ci(firebase): drop projects:list preflight

### DIFF
--- a/.github/workflows/main-verify-deploy.yml
+++ b/.github/workflows/main-verify-deploy.yml
@@ -41,14 +41,6 @@ jobs:
         with:
           service-account-json: ${{ env.FIREBASE_DEPLOY_SERVICE_ACCOUNT_JSON }}
 
-      - name: Validate Firebase auth and project access
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_path }}
-        run: |
-          pnpm exec firebase projects:list \
-            --project "$FIREBASE_PROJECT_ID" \
-            --non-interactive 2>&1
-
       - name: Validate Functions secret access
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_path }}


### PR DESCRIPTION
## Summary
- `firebase projects:list` does NOT honor `GOOGLE_APPLICATION_CREDENTIALS` — fails with "Failed to authenticate, have you run firebase login?" even with a valid SA key.
- The next step `functions:secrets:access` DOES honor ADC and is a meaningful auth gate.
- Drop the broken projects:list step. This unblocks prod deploys (blocked since 2026-04-22).

## Test plan
- [ ] PR-Verify passes
- [ ] On merge, post-merge `auth-preflight` job succeeds and `deploy` runs