### PR TITLE
ci(firebase): Phase A WIF migration

### DIFF
--- a/.github/actions/firebase-auth-wif/action.yml
+++ b/.github/actions/firebase-auth-wif/action.yml
@@ -1,0 +1,40 @@
+name: 'Firebase Auth via Workload Identity Federation'
+description: 'Exchange GitHub OIDC token for Firebase service account credentials via WIF'
+
+inputs:
+  workload_identity_provider:
+    description: 'GCP Workload Identity Provider resource name'
+    required: true
+  service_account:
+    description: 'Firebase service account email'
+    required: true
+
+outputs:
+  credentials_path:
+    description: 'Absolute path to generated credentials file (short-lived access token)'
+    value: ${{ steps.wif.outputs.credentials_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Google Cloud via WIF
+      id: wif
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+        service_account: ${{ inputs.service_account }}
+        token_format: 'access_token'
+        access_token_lifetime: '1200s'
+
+    - name: Export ADC and credentials path
+      shell: bash
+      run: |
+        # The auth action sets GOOGLE_APPLICATION_CREDENTIALS in the environment.
+        # For Firebase CLI compatibility, we also export the access token path.
+        CREDENTIALS_PATH="${{ steps.wif.outputs.credentials_file }}"
+        if [ -z "$CREDENTIALS_PATH" ]; then
+          echo "::error::WIF auth failed to produce credentials file"
+          exit 1
+        fi
+        echo "credentials_path=$CREDENTIALS_PATH" >> "$GITHUB_OUTPUT"
+        echo "Access token path: $CREDENTIALS_PATH"

--- a/.github/workflows/firebase-manual-deploy-service.yml
+++ b/.github/workflows/firebase-manual-deploy-service.yml
@@ -45,9 +45,11 @@ jobs:
     name: deploy-manual
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
     env:
       FIREBASE_PROJECT_ID: rush-n-relax
-      FIREBASE_DEPLOY_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_RUSH_N_RELAX }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -66,11 +68,12 @@ jobs:
           deploy_firestore_indexes: ${{ github.event.inputs.deploy_firestore_indexes }}
           deploy_storage_rules: ${{ github.event.inputs.deploy_storage_rules }}
 
-      - name: Setup Firebase auth
+      - name: Setup Firebase auth via WIF
         id: auth
-        uses: ./.github/actions/firebase-auth-setup
+        uses: ./.github/actions/firebase-auth-wif
         with:
-          service-account-json: ${{ env.FIREBASE_DEPLOY_SERVICE_ACCOUNT_JSON }}
+          workload_identity_provider: projects/556383052079/locations/global/workloadIdentityPools/rush-n-relax-wif/providers/github-provider
+          service_account: firebase-adminsdk-fbsvc@rush-n-relax.iam.gserviceaccount.com
 
       - name: Preflight Functions secret access
         if: ${{ steps.selector.outputs.target_only == '' || contains(steps.selector.outputs.target_only, 'functions') }}

--- a/.github/workflows/main-verify-deploy.yml
+++ b/.github/workflows/main-verify-deploy.yml
@@ -25,9 +25,11 @@ jobs:
     if: github.event.pull_request.merged == true && needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
     env:
       FIREBASE_PROJECT_ID: rush-n-relax
-      FIREBASE_DEPLOY_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_RUSH_N_RELAX }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -35,11 +37,12 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Setup Firebase auth
+      - name: Setup Firebase auth via WIF
         id: auth
-        uses: ./.github/actions/firebase-auth-setup
+        uses: ./.github/actions/firebase-auth-wif
         with:
-          service-account-json: ${{ env.FIREBASE_DEPLOY_SERVICE_ACCOUNT_JSON }}
+          workload_identity_provider: projects/556383052079/locations/global/workloadIdentityPools/rush-n-relax-wif/providers/github-provider
+          service_account: firebase-adminsdk-fbsvc@rush-n-relax.iam.gserviceaccount.com
 
       - name: Validate Functions secret access
         env:
@@ -136,8 +139,10 @@ jobs:
     if: github.event.pull_request.merged == true && needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     env:
-      FIREBASE_DEPLOY_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_RUSH_N_RELAX }}
       FIREBASE_PROJECT_ID: rush-n-relax
     steps:
       - name: Checkout code
@@ -148,11 +153,12 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Setup Firebase auth
+      - name: Setup Firebase auth via WIF
         id: auth
-        uses: ./.github/actions/firebase-auth-setup
+        uses: ./.github/actions/firebase-auth-wif
         with:
-          service-account-json: ${{ env.FIREBASE_DEPLOY_SERVICE_ACCOUNT_JSON }}
+          workload_identity_provider: projects/556383052079/locations/global/workloadIdentityPools/rush-n-relax-wif/providers/github-provider
+          service_account: firebase-adminsdk-fbsvc@rush-n-relax.iam.gserviceaccount.com
 
       - name: Build Cloud Functions
         run: cd functions && npm ci && npm run build


### PR DESCRIPTION
## Summary

Implement Workload Identity Federation (WIF) for GitHub Actions Firebase deployments, replacing service account secrets with short-lived OIDC tokens.

- Add `firebase-auth-wif` action to exchange GitHub OIDC token for GCP access token
- Update `main-verify-deploy` and `firebase-manual-deploy-service` workflows to use WIF
- Add required `id-token: write` permission to deploy jobs
- GCP WIF binding already configured at service account level

## WIF Configuration

**Workload Identity Provider:**
```
projects/556383052079/locations/global/workloadIdentityPools/rush-n-relax-wif/providers/github-provider
```

**Service Account:**
```
firebase-adminsdk-fbsvc@rush-n-relax.iam.gserviceaccount.com
```

**Principal Binding (attribute-based):**
```
principalSet://iam.googleapis.com/projects/556383052079/locations/global/workloadIdentityPools/rush-n-relax-wif/attribute.repository/brewski-beers/rush-n-relax
```

This binding allows all workflows from the `brewski-beers/rush-n-relax` repository to authenticate as the Firebase admin service account.

## Verification

Before merging, verify the WIF binding is in place:

```bash
gcloud iam service-accounts get-iam-policy \
  firebase-adminsdk-fbsvc@rush-n-relax.iam.gserviceaccount.com \
  --project=rush-n-relax
```

Expected output should show the principalSet binding with role `roles/iam.workloadIdentityUser`.

## Test Plan

- [x] WIF binding created in GCP (service account IAM policy)
- [x] New `firebase-auth-wif` action validated against google-github-actions/auth v2
- [x] Workflows updated to use WIF (main-verify-deploy, firebase-manual-deploy-service)
- [x] Commit passes pre-commit hooks (prettier, stylelint)
- [ ] Merge and monitor next production deployment for WIF token exchange success

🤖 Generated with Claude Code