### PR TITLE
fix(ci): use correct WIF output name credentials_file_path

### DIFF
--- a/.github/actions/firebase-auth-wif/action.yml
+++ b/.github/actions/firebase-auth-wif/action.yml
@@ -31,7 +31,7 @@ runs:
       run: |
         # The auth action sets GOOGLE_APPLICATION_CREDENTIALS in the environment.
         # For Firebase CLI compatibility, we also export the access token path.
-        CREDENTIALS_PATH="${{ steps.wif.outputs.credentials_file }}"
+        CREDENTIALS_PATH="${{ steps.wif.outputs.credentials_file_path }}"
         if [ -z "$CREDENTIALS_PATH" ]; then
           echo "::error::WIF auth failed to produce credentials file"
           exit 1


### PR DESCRIPTION
## Summary
The composite action read `steps.wif.outputs.credentials_file` — wrong key name. The action outputs `credentials_file_path`. The empty string then tripped the post-auth guard, even though auth itself succeeded and `GOOGLE_APPLICATION_CREDENTIALS` was correctly set.

This is the post-merge fixup for #258 — WIF auth was actually working; the guard logic was wrong.

## Test plan
- [ ] Post-merge `auth-preflight` step `Setup Firebase auth via WIF` succeeds
- [ ] `Validate Functions secret access` step passes
- [ ] `deploy` job runs and ships to prod