### PR TITLE
fix(ci): correct WIF composite output binding

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"dc755554-7af5-4c4b-8bf1-72a809164945","pid":11834,"procStart":"Sat Apr 25 14:16:27 2026","acquiredAt":1777127291308}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"dc755554-7af5-4c4b-8bf1-72a809164945","pid":11834,"procStart":"Sat Apr 25 14:16:27 2026","acquiredAt":1777127291308}

--- a/.github/actions/firebase-auth-wif/action.yml
+++ b/.github/actions/firebase-auth-wif/action.yml
@@ -12,7 +12,7 @@ inputs:
 outputs:
   credentials_path:
     description: 'Absolute path to generated credentials file (short-lived access token)'
-    value: ${{ steps.wif.outputs.credentials_path }}
+    value: ${{ steps.wif.outputs.credentials_file_path }}
 
 runs:
   using: composite

--- a/.github/workflows/firebase-manual-deploy-service.yml
+++ b/.github/workflows/firebase-manual-deploy-service.yml
@@ -77,8 +77,6 @@ jobs:
 
       - name: Preflight Functions secret access
         if: ${{ steps.selector.outputs.target_only == '' || contains(steps.selector.outputs.target_only, 'functions') }}
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_path }}
         run: |
           pnpm exec firebase functions:secrets:access GOOGLE_PLACES_API_KEY \
             --project "$FIREBASE_PROJECT_ID" \

--- a/.github/workflows/main-verify-deploy.yml
+++ b/.github/workflows/main-verify-deploy.yml
@@ -45,16 +45,10 @@ jobs:
           service_account: firebase-adminsdk-fbsvc@rush-n-relax.iam.gserviceaccount.com
 
       - name: Validate Functions secret access
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_path }}
         run: |
           pnpm exec firebase functions:secrets:access GOOGLE_PLACES_API_KEY \
             --project "$FIREBASE_PROJECT_ID" \
             --non-interactive
-
-      - name: Cleanup preflight credentials
-        if: always()
-        run: rm -f "${{ steps.auth.outputs.credentials_path }}"
 
   verify:
     name: verify

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ serviceAccountKey.json
 .claude/memory/
 .claire/
 .vercel
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
Two bugs in #258 only partially fixed by #259:

1. **Composite action output binding** — `outputs.credentials_path.value` referenced `steps.wif.outputs.credentials_path` (wrong); auth@v2 emits `credentials_file_path`. The empty value flowed to the validate step's `env:` override, blanking `GOOGLE_APPLICATION_CREDENTIALS` and breaking `firebase functions:secrets:access` with "Failed to authenticate, have you run firebase login?".
2. **Redundant env override removed** — auth@v2 already exports `GOOGLE_APPLICATION_CREDENTIALS` globally. The manual override is a footgun (as we just learned). Also dropped the manual cleanup; auth@v2's `cleanup_credentials: true` default handles it.

Plus untracked `.claude/scheduled_tasks.lock` (added to .gitignore).

## Test plan
- [ ] Post-merge `auth-preflight` succeeds end-to-end (WIF token + `firebase functions:secrets:access`)
- [ ] `deploy` job runs and ships to prod