### PR TITLE
security: rotate Obsidian API key out of .mcp.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,3 +118,19 @@ On session start, load these for context (see global CLAUDE.md for the `cat $KNO
 
 - [[handoff-self-documentation]]
 
+---
+
+## Local Setup — MCP Secrets
+
+`.mcp.json` is a symlink to `~/Developer/BrewCortex/.mcp.json` (shared across all KB projects). It uses env-var interpolation for secrets — no live keys are committed.
+
+To enable the Obsidian MCP server locally, export `OBSIDIAN_API_KEY` in your shell profile:
+
+```bash
+# ~/.zshrc
+export OBSIDIAN_API_KEY="<your-obsidian-local-rest-api-key>"
+```
+
+Get the key from Obsidian → Settings → Community Plugins → Local REST API → API Key.
+
+Never commit a literal value into `.mcp.json`. If a new MCP server needs a secret, follow the same `${ENV_VAR}` pattern.


### PR DESCRIPTION
Closes #253

## Approach

`.mcp.json` in this repo is a **symlink** to `~/Developer/BrewCortex/.mcp.json` (the shared MCP config across KB's projects). The current resolved file already uses `${OBSIDIAN_API_KEY}` env-var interpolation — no literal key is in the tracked file.

Investigation:
- `git log -p -- .mcp.json` in rush-n-relax shows the symlink was added in `549901d` (PR #172). The literal key was **never** committed in this repo's history (only the symlink path).
- The literal key (`7b00f3fd…`) was committed in the **BrewCortex** repo (commits `b3d01d0` add, `f576f43` rotation to env-var). That repo is private/local-only and was already remediated.
- Net effect for rush-n-relax: no history rewrite needed here — the secret never existed in this repo's git objects.

This PR adds a `Local Setup — MCP Secrets` section to `CLAUDE.md` documenting the env-var pattern so future devs/Claude know to export `OBSIDIAN_API_KEY` and never inline a literal.

## Other secrets audited

`.mcp.json` contains:
- `OBSIDIAN_API_KEY` — env-var reference, ✅ safe
- `OBSIDIAN_VAULT_PATH` — local filesystem path, not a secret
- `context7` server — no env vars

No other secrets present.

## Verification

```
$ git -C /tmp/rnr-obsidian-key ls-files | xargs grep -l 'OBSIDIAN_API_KEY'
.mcp.json   # only the env-var reference ${OBSIDIAN_API_KEY}, no literal
CLAUDE.md   # docs reference only
```

No literal key value in any tracked file.

## TODO for KB (manual)

- [ ] Rotate the live key in Obsidian Settings → Community Plugins → Local REST API → regenerate
- [ ] Update `OBSIDIAN_API_KEY` in shell profile (`~/.zshrc`) with new value
- [ ] Log incident in `vault/projects/rush-n-relax/patterns.md` Secrets section (worker did not have iCloud vault path access from worktree)

## History rewrite decision

**Recommendation: accept-rotation-only. No force-rewrite needed for rush-n-relax.**

Rationale: the literal key never existed in rush-n-relax's git history (only the symlink target path was committed). The literal value lived only in the BrewCortex repo, which is local/private. Once KB rotates the live key per the TODO above, exposure is fully closed. Force-rewriting rush-n-relax history would be no-op for this incident and would invalidate all open PRs/forks.

If KB wants belt-and-suspenders cleanup of the BrewCortex repo history, that's a separate ticket against BrewCortex (BFG or `git filter-repo` on `.mcp.json`).